### PR TITLE
feat: require 10-minute minimum playtime per period for hero stats

### DIFF
--- a/backend/app-service/src/services/hero/service.py
+++ b/backend/app-service/src/services/hero/service.py
@@ -537,6 +537,7 @@ async def get_hero_leaderboard(
             ).cast(sa.Numeric(10, 2)).label("kda"),
         )
         .select_from(sums_cte)
+        .where(sums_cte.c.total_playtime >= 600)
     ).cte("stats_agg")
 
     player_rn_subq = (

--- a/backend/app-service/src/services/user/flows.py
+++ b/backend/app-service/src/services/user/flows.py
@@ -519,6 +519,8 @@ async def get_hero_compare(
         div_max=compare_div_max,
         tournament_id=params.tournament_id,
     )
+    if left_playtime < 600:
+        left_stats = {}
 
     if mode == "target_user":
         target_model = await get(session, params.target_user_id, [])
@@ -530,6 +532,8 @@ async def get_hero_compare(
             stats=requested_stats,
             tournament_id=params.tournament_id,
         )
+        if right_playtime < 600:
+            right_stats = {}
         target = schemas.UserCompareUser(id=target_model.id, name=target_model.name)
         baseline_target = target
         sample_size = 1
@@ -560,7 +564,7 @@ async def get_hero_compare(
             tournament_id=params.tournament_id,
         )
 
-        sample_user_ids = [user_id for user_id, playtime in baseline_playtime_by_user.items() if playtime > 0]
+        sample_user_ids = [user_id for user_id, playtime in baseline_playtime_by_user.items() if playtime >= 600]
         if not sample_user_ids:
             raise errors.ApiHTTPException(
                 status_code=404,


### PR DESCRIPTION
Add a secondary filter on top of the existing per-match 1-minute condition: users must have accumulated at least 600 seconds (10 min) on a hero within the selected period (all-time or specific tournament) to be included in statistics.

Applied to:
- /users/{id}/compare/heroes — subject, target user, and population baseline
- /heroes/{hero_id}/leaderboard — stats_agg CTE filtered by total_playtime >= 600