### PR TITLE
fix: align hero KD/KDA formulas across leaderboard and achievements

### DIFF
--- a/backend/app-service/src/services/hero/service.py
+++ b/backend/app-service/src/services/hero/service.py
@@ -530,10 +530,11 @@ async def get_hero_leaderboard(
             _avg_pct(sums_cte.c.sum_crit_accuracy,      sums_cte.c.count_crit_accuracy).label("avg_crit_accuracy"),
             # Derived ratios (not per-10-min — deaths cancel out)
             sa.func.coalesce(
-                sums_cte.c.sum_final_blows / sa.func.nullif(sums_cte.c.sum_deaths, 0), 0
+                sums_cte.c.sum_eliminations / sa.func.nullif(sums_cte.c.sum_deaths, 0), 0
             ).cast(sa.Numeric(10, 2)).label("kd"),
             sa.func.coalesce(
-                sums_cte.c.sum_eliminations / sa.func.nullif(sums_cte.c.sum_deaths, 0), 0
+                (sums_cte.c.sum_eliminations + sums_cte.c.sum_offensive_assists + sums_cte.c.sum_defensive_assists)
+                / sa.func.nullif(sums_cte.c.sum_deaths, 0), 0
             ).cast(sa.Numeric(10, 2)).label("kda"),
         )
         .select_from(sums_cte)

--- a/backend/parser-service/src/services/achievement/service/hero.py
+++ b/backend/parser-service/src/services/achievement/service/hero.py
@@ -38,7 +38,10 @@ async def create_hero_kd_achievements(session: AsyncSession, tournament: models.
                     models.Encounter.tournament_id == tournament.id,
                     models.MatchStatistics.hero_id == hero.id,
                     models.MatchStatistics.round == 0,
-                    models.MatchStatistics.name.in_([enums.LogStatsName.KD, enums.LogStatsName.HeroTimePlayed]),
+                    models.MatchStatistics.name.in_([
+                        enums.LogStatsName.KD,
+                        enums.LogStatsName.HeroTimePlayed,
+                    ]),
                 )
             )
             .cte("base_stats_cte")


### PR DESCRIPTION
Leaderboard (hero/service.py):
- kd: use Eliminations/Deaths instead of FinalBlows/Deaths
- kda: fix bug where kda was identical to kd; now uses (Eliminations + OffensiveAssists + DefensiveAssists) / Deaths, matching the parser-stored KDA formula

Achievement (achievement/service/hero.py):
- Use the parser-stored KD stat directly instead of re-deriving it from raw Eliminations and Deaths columns
- Aggregate as AVG(kd) over qualifying matches