### PR TITLE
feat(balancer): configurable rank-autofill chain, lookback windows, p…

### DIFF
--- a/backend/tournament-service/src/routes/admin/registration.py
+++ b/backend/tournament-service/src/routes/admin/registration.py
@@ -339,7 +339,9 @@ async def preview_registration_rank_autofill(
         registration_ids=data.registration_ids,
         overwrite_existing=data.overwrite_existing,
         add_to_balancer=data.add_to_balancer,
+        allow_partial=data.allow_partial,
         mode=data.mode,
+        stages=data.stages,
         apply=False,
     )
     return admin_schemas.BalancerRegistrationRankAutofillResponse(**result)
@@ -361,7 +363,9 @@ async def apply_registration_rank_autofill(
         registration_ids=data.registration_ids,
         overwrite_existing=data.overwrite_existing,
         add_to_balancer=data.add_to_balancer,
+        allow_partial=data.allow_partial,
         mode=data.mode,
+        stages=data.stages,
         apply=True,
     )
     return admin_schemas.BalancerRegistrationRankAutofillResponse(**result)

--- a/backend/tournament-service/src/schemas/admin/balancer.py
+++ b/backend/tournament-service/src/schemas/admin/balancer.py
@@ -19,14 +19,18 @@ RankAutofillRoleAction = Literal[
     "set",
     "overwrite",
     "keep_existing",
+    "unverified",
     "missing_rank",
     "blocked",
 ]
 RankAutofillSource = Literal["analytics", "balancer"]
 RankAutofillUsedSource = Literal["division_history", "ow", "analytics"]
+# Individual source of a rank-autofill stage chain.
+RankAutofillSourceKey = Literal["ow", "division_history", "analytics"]
 # Priority chains for rank autofill:
 #   ow_first       -> OW (week composite) -> balancer (division history) -> analytics (past tournaments)
 #   balancer_first -> balancer -> analytics -> OW
+# Legacy presets; superseded by an explicit ``stages`` chain when one is supplied.
 RankAutofillMode = Literal["ow_first", "balancer_first"]
 
 __all__ = (
@@ -54,6 +58,7 @@ __all__ = (
     "BalancerRegistrationCreateRequest",
     "BalancerRegistrationExclusionRequest",
     "BalancerRegistrationRead",
+    "BalancerRankAutofillStage",
     "BalancerRegistrationRankAutofillRequest",
     "BalancerRegistrationRankAutofillResponse",
     "BalancerRegistrationRankAutofillPlayer",
@@ -220,11 +225,32 @@ class BalancerRegistrationRoleInput(BaseModel):
     top_heroes: list[str] | None = None
 
 
+class BalancerRankAutofillStage(BaseModel):
+    """A single source in the rank-autofill priority chain.
+
+    ``lookback_tournaments`` limits ``division_history``/``analytics`` to tournaments whose number is
+    within the last N before the current one; ``lookback_days`` overrides the OW weekly window. The
+    irrelevant lookback for a given ``source`` is ignored by the service.
+    """
+
+    source: RankAutofillSourceKey
+    enabled: bool = True
+    lookback_tournaments: int | None = Field(None, ge=1)
+    lookback_days: int | None = Field(None, ge=1)
+
+
 class BalancerRegistrationRankAutofillRequest(BaseModel):
     registration_ids: list[int] | None = None
     overwrite_existing: bool = False
     add_to_balancer: bool = False
+    # Apply found role ranks even when other active roles have no parsed rank (otherwise the whole
+    # registration is skipped). Never clears an existing rank — unfilled roles are left untouched.
+    allow_partial: bool = False
+    # Legacy preset; only used when ``stages`` is not supplied.
     mode: RankAutofillMode = "ow_first"
+    # Explicit ordered priority chain. When non-empty it supersedes ``mode``; disabled stages are
+    # dropped and duplicate sources are de-duplicated, preserving order.
+    stages: list[BalancerRankAutofillStage] | None = None
 
 
 class BalancerRegistrationRankAutofillRole(BaseModel):
@@ -254,6 +280,8 @@ class BalancerRegistrationRankAutofillPlayer(BaseModel):
     reason: str | None = None
     will_add_to_balancer: bool = False
     balancer_reason: str | None = None
+    # True when some active roles were filled but others had no parsed rank (allow_partial).
+    partial: bool = False
     roles: list[BalancerRegistrationRankAutofillRole] = Field(default_factory=list)
 
 
@@ -263,6 +291,8 @@ class BalancerRegistrationRankAutofillResponse(BaseModel):
     applied_registrations: int
     skipped_registrations: int
     unchanged_registrations: int
+    # Registrations with >=1 active role that has a current rank no enabled source could corroborate.
+    unverified_registrations: int
     role_updates: int
     overwrite_existing: bool
     add_to_balancer: bool

--- a/backend/tournament-service/src/services/registration/admin.py
+++ b/backend/tournament-service/src/services/registration/admin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -112,6 +112,20 @@ class _OwRankSignals:
 
     composite_rank_value: int | None = None
     latest_snapshot: models.UserRankSnapshot | Any | None = None
+
+
+@dataclass(frozen=True)
+class _ResolvedAutofillStage:
+    """One enabled source in the resolved autofill chain, with its lookback window.
+
+    ``lookback_tournaments`` applies to the tournament-based sources (``division_history``,
+    ``analytics``); ``lookback_days`` overrides the OW weekly window. The irrelevant field for a
+    given ``source`` is simply ignored by the orchestrator.
+    """
+
+    source: str
+    lookback_tournaments: int | None = None
+    lookback_days: int | None = None
 
 
 # Registration role code -> canonical RankRole value (e.g. dps -> damage). Single source of
@@ -1268,12 +1282,16 @@ def build_registration_rank_autofill_plan(
     *,
     battle_tag_linked: bool,
     overwrite_existing: bool,
+    allow_partial: bool = False,
     applied: bool = False,
 ) -> tuple[dict[str, Any], list[tuple[Any, Any]]]:
     """Build the rank autofill preview row and pending role updates.
 
-    Only active registration roles are considered, and parsed ranks are expected
-    to come from the registration's main battle tag only.
+    Only active registration roles are considered, and parsed ranks are expected to come from the
+    registration's main battle tag only. With ``allow_partial`` the found role ranks are still
+    applied when other active roles have no parsed rank (instead of skipping the whole registration);
+    unfilled roles are left untouched — an existing rank is never cleared. A role that has a current
+    rank no enabled source could corroborate is reported as ``unverified`` (informational only).
     """
 
     display_name = getattr(registration, "display_name", None)
@@ -1284,6 +1302,7 @@ def build_registration_rank_autofill_plan(
         "battle_tag": battle_tag,
         "status": "skipped",
         "reason": None,
+        "partial": False,
         "roles": [],
     }
 
@@ -1324,8 +1343,12 @@ def build_registration_rank_autofill_plan(
 
         if current_rank is not None and not overwrite_existing:
             kept_existing = True
-            role_row["action"] = "keep_existing"
-            role_row["reason"] = "Existing registration rank is kept. Enable overwrite to replace it."
+            if parsed_rank is None:
+                role_row["action"] = "unverified"
+                role_row["reason"] = "Current rank kept; no enabled source found a value to verify it."
+            else:
+                role_row["action"] = "keep_existing"
+                role_row["reason"] = "Existing registration rank is kept. Enable overwrite to replace it."
         elif parsed_rank is None:
             missing_roles.append(REGISTRATION_ROLE_LABELS.get(role_code, str(role_code)))
         elif current_rank == parsed_rank:
@@ -1339,7 +1362,8 @@ def build_registration_rank_autofill_plan(
 
         row["roles"].append(role_row)
 
-    if missing_roles:
+    if missing_roles and not allow_partial:
+        # All-or-nothing: one unparsed role skips the whole registration and blocks its updates.
         row["reason"] = f"No parsed rank for registered role(s): {', '.join(missing_roles)}."
         for role_row in row["roles"]:
             if role_row["action"] in {"set", "overwrite"}:
@@ -1349,7 +1373,16 @@ def build_registration_rank_autofill_plan(
 
     if updates:
         row["status"] = "applied" if applied else "will_update"
+        if missing_roles:
+            # allow_partial: apply what was found, leave the unparsed roles untouched.
+            row["partial"] = True
+            row["reason"] = f"Partial: applied found ranks; no parsed rank for {', '.join(missing_roles)}."
         return row, updates
+
+    if missing_roles:
+        # allow_partial but nothing to apply (the parsed roles already matched / were kept).
+        row["reason"] = f"No parsed rank for registered role(s): {', '.join(missing_roles)}."
+        return row, []
 
     row["status"] = "unchanged"
     row["reason"] = (
@@ -1459,48 +1492,53 @@ async def _load_latest_ranks_from_balancer_history(
     workspace_id: int,
     normalizer: DivisionGridNormalizer | None,
     target_grid: DivisionGrid,
+    min_tournament_number: int | None = None,
 ) -> dict[int, dict[str, int]]:
     """Return dict[user_id][role_code] → rank_value from past registration records.
 
     Searches the workspace's previous tournaments (excluding the current one), ordered
     by tournament number descending so the most recent entry wins. Ranks are normalized from
-    each source tournament's grid version into the target grid.
+    each source tournament's grid version into the target grid. When ``min_tournament_number`` is
+    set, only tournaments whose ``number`` is at least that cutoff are considered (recency window;
+    rows with a ``NULL`` number naturally fall outside the window).
     """
     if not user_ids:
         return {}
 
-    rows = (
-        await session.execute(
-            sa.select(
-                models.BalancerRegistration.user_id,
-                models.BalancerRegistrationRole.role,
-                models.BalancerRegistrationRole.rank_value,
-                models.Tournament.division_grid_version_id,
-            )
-            .join(
-                models.BalancerRegistrationRole,
-                models.BalancerRegistrationRole.registration_id == models.BalancerRegistration.id,
-            )
-            .join(
-                models.Tournament,
-                models.Tournament.id == models.BalancerRegistration.tournament_id,
-            )
-            .where(
-                models.BalancerRegistration.user_id.in_(user_ids),
-                models.Tournament.workspace_id == workspace_id,
-                models.BalancerRegistration.tournament_id != current_tournament_id,
-                models.BalancerRegistration.deleted_at.is_(None),
-                models.BalancerRegistrationRole.is_active.is_(True),
-                models.BalancerRegistrationRole.rank_value.is_not(None),
-            )
-            .order_by(
-                models.BalancerRegistration.user_id,
-                models.BalancerRegistrationRole.role,
-                models.Tournament.number.desc().nullslast(),
-                models.BalancerRegistration.tournament_id.desc(),
-            )
+    stmt = (
+        sa.select(
+            models.BalancerRegistration.user_id,
+            models.BalancerRegistrationRole.role,
+            models.BalancerRegistrationRole.rank_value,
+            models.Tournament.division_grid_version_id,
         )
-    ).all()
+        .join(
+            models.BalancerRegistrationRole,
+            models.BalancerRegistrationRole.registration_id == models.BalancerRegistration.id,
+        )
+        .join(
+            models.Tournament,
+            models.Tournament.id == models.BalancerRegistration.tournament_id,
+        )
+        .where(
+            models.BalancerRegistration.user_id.in_(user_ids),
+            models.Tournament.workspace_id == workspace_id,
+            models.BalancerRegistration.tournament_id != current_tournament_id,
+            models.BalancerRegistration.deleted_at.is_(None),
+            models.BalancerRegistrationRole.is_active.is_(True),
+            models.BalancerRegistrationRole.rank_value.is_not(None),
+        )
+        .order_by(
+            models.BalancerRegistration.user_id,
+            models.BalancerRegistrationRole.role,
+            models.Tournament.number.desc().nullslast(),
+            models.BalancerRegistration.tournament_id.desc(),
+        )
+    )
+    if min_tournament_number is not None:
+        stmt = stmt.where(models.Tournament.number >= min_tournament_number)
+
+    rows = (await session.execute(stmt)).all()
 
     latest: dict[int, dict[str, int]] = {}
     for row in rows:
@@ -1521,6 +1559,7 @@ async def _load_latest_ranks_from_tournament_history(
     workspace_id: int,
     normalizer: DivisionGridNormalizer | None,
     target_grid: DivisionGrid,
+    min_tournament_number: int | None = None,
 ) -> dict[int, dict[str, int]]:
     """Return dict[user_id][registration_role_code] → rank from past tournament participation.
 
@@ -1528,39 +1567,43 @@ async def _load_latest_ranks_from_tournament_history(
     (``tournament.player``), distinct from the balancer-registration history. Excludes the current
     tournament and substitution rows; the most recent tournament wins per role. ``Player.role`` is
     a HeroClass and is bridged to the registration role code (Damage → dps) to match keying. Ranks
-    are normalized from each source tournament's grid version into the target grid.
+    are normalized from each source tournament's grid version into the target grid. When
+    ``min_tournament_number`` is set, only tournaments whose ``number`` is at least that cutoff are
+    considered (recency window; rows with a ``NULL`` number naturally fall outside the window).
     """
     if not user_ids:
         return {}
 
-    rows = (
-        await session.execute(
-            sa.select(
-                models.Player.user_id,
-                models.Player.role,
-                models.Player.rank,
-                models.Tournament.division_grid_version_id,
-            )
-            .join(
-                models.Tournament,
-                models.Tournament.id == models.Player.tournament_id,
-            )
-            .where(
-                models.Player.user_id.in_(user_ids),
-                models.Tournament.workspace_id == workspace_id,
-                models.Player.tournament_id != current_tournament_id,
-                models.Player.role.is_not(None),
-                models.Player.is_substitution.is_(False),
-                models.Player.rank > 0,
-            )
-            .order_by(
-                models.Player.user_id,
-                models.Player.role,
-                models.Tournament.number.desc().nullslast(),
-                models.Player.tournament_id.desc(),
-            )
+    stmt = (
+        sa.select(
+            models.Player.user_id,
+            models.Player.role,
+            models.Player.rank,
+            models.Tournament.division_grid_version_id,
         )
-    ).all()
+        .join(
+            models.Tournament,
+            models.Tournament.id == models.Player.tournament_id,
+        )
+        .where(
+            models.Player.user_id.in_(user_ids),
+            models.Tournament.workspace_id == workspace_id,
+            models.Player.tournament_id != current_tournament_id,
+            models.Player.role.is_not(None),
+            models.Player.is_substitution.is_(False),
+            models.Player.rank > 0,
+        )
+        .order_by(
+            models.Player.user_id,
+            models.Player.role,
+            models.Tournament.number.desc().nullslast(),
+            models.Player.tournament_id.desc(),
+        )
+    )
+    if min_tournament_number is not None:
+        stmt = stmt.where(models.Tournament.number >= min_tournament_number)
+
+    rows = (await session.execute(stmt)).all()
 
     latest: dict[int, dict[str, int]] = {}
     for row in rows:
@@ -1678,6 +1721,7 @@ async def _load_ow_rank_signals_by_battle_tag_id(
     session: AsyncSession,
     battle_tag_ids: list[int],
     now: datetime,
+    week_window: timedelta = OW_RANK_WEEK_WINDOW,
 ) -> dict[int, dict[str, _OwRankSignals]]:
     """Return per (battle_tag_id, rank_role) the weekly OW rank composite + latest snapshot."""
     if not battle_tag_ids:
@@ -1692,17 +1736,18 @@ async def _load_ow_rank_signals_by_battle_tag_id(
         )
         .order_by(models.UserRankSnapshot.captured_at.desc(), models.UserRankSnapshot.id.desc())
     )
-    return _group_ow_rank_signals(result.scalars().all(), now)
+    return _group_ow_rank_signals(result.scalars().all(), now, week_window)
 
 
 def _group_ow_rank_signals(
     snapshots_newest_first: Iterable[models.UserRankSnapshot | Any],
     now: datetime,
+    week_window: timedelta = OW_RANK_WEEK_WINDOW,
 ) -> dict[int, dict[str, _OwRankSignals]]:
     """Group newest-first snapshots into per (battle_tag_id, role) weekly OW signals.
 
     Pure (no DB) so the windowing logic can be unit-tested. For each (tag, role) the composite
-    rank is ``round((max + mean) / 2)`` over the weekly window (see ``_compute_ow_week_rank_value``);
+    rank is ``round((max + mean) / 2)`` over the ``week_window`` (see ``_compute_ow_week_rank_value``);
     the first snapshot seen (newest) is kept as the latest for display metadata.
     """
     grouped: dict[int, dict[str, list[Any]]] = {}
@@ -1714,7 +1759,7 @@ def _group_ow_rank_signals(
         out = signals_by_tag_id.setdefault(tag_id, {})
         for role, snaps in role_map.items():
             out[role] = _OwRankSignals(
-                composite_rank_value=_compute_ow_week_rank_value(snaps, now),
+                composite_rank_value=_compute_ow_week_rank_value(snaps, now, week_window),
                 latest_snapshot=snaps[0] if snaps else None,
             )
     return signals_by_tag_id
@@ -1723,12 +1768,13 @@ def _group_ow_rank_signals(
 def _compute_ow_week_rank_value(
     snapshots: Iterable[models.UserRankSnapshot | Any],
     now: datetime,
+    week_window: timedelta = OW_RANK_WEEK_WINDOW,
 ) -> int | None:
     """Composite OW rank over a weekly window: ``round((max + mean) / 2)`` of mapped rank_value.
 
-    Window selection (per role):
-      1. snapshots captured within the last 7 days from ``now``;
-      2. if none, snapshots within 7 days of the player's most recent snapshot;
+    Window selection (per role), using ``week_window`` (default 7 days):
+      1. snapshots captured within the last ``week_window`` from ``now``;
+      2. if none, snapshots within ``week_window`` of the player's most recent snapshot;
       3. if still none (no usable timestamps), the single most-recent snapshot.
     Returns ``None`` only when there are no snapshots carrying a ``rank_value``.
     """
@@ -1737,10 +1783,10 @@ def _compute_ow_week_rank_value(
         return None
 
     dated = [s for s in snaps if getattr(s, "captured_at", None) is not None]
-    window = [s for s in dated if s.captured_at >= now - OW_RANK_WEEK_WINDOW]
+    window = [s for s in dated if s.captured_at >= now - week_window]
     if not window and dated:
         latest_at = max(s.captured_at for s in dated)
-        window = [s for s in dated if s.captured_at >= latest_at - OW_RANK_WEEK_WINDOW]
+        window = [s for s in dated if s.captured_at >= latest_at - week_window]
     if not window:
         window = [snaps[0]]
 
@@ -1748,19 +1794,60 @@ def _compute_ow_week_rank_value(
     return round((max(values) + sum(values) / len(values)) / 2)
 
 
+# Legacy ``mode`` presets, expressed as a default stage order. Used only when no explicit stage
+# chain is supplied on the request.
+_DEFAULT_STAGE_ORDER_BY_MODE: dict[str, tuple[str, ...]] = {
+    "ow_first": ("ow", "division_history", "analytics"),
+    "balancer_first": ("division_history", "analytics", "ow"),
+}
+
+
+def resolve_autofill_stages(
+    mode: str | None,
+    stages: Sequence[Any] | None,
+) -> list[_ResolvedAutofillStage]:
+    """Resolve the effective, ordered list of enabled autofill stages.
+
+    When ``stages`` is non-empty it wins: disabled entries are dropped and duplicate sources are
+    de-duplicated (first occurrence kept), preserving order. Otherwise the legacy ``mode`` preset
+    order is used, with no lookback windows. ``stages`` items are duck-typed (``source``,
+    ``enabled``, ``lookback_tournaments``, ``lookback_days``) so unit tests can pass simple objects.
+    """
+    if stages:
+        resolved: list[_ResolvedAutofillStage] = []
+        seen: set[str] = set()
+        for stage in stages:
+            if not getattr(stage, "enabled", True):
+                continue
+            source = getattr(stage, "source", None)
+            if source is None or source in seen:
+                continue
+            seen.add(source)
+            resolved.append(
+                _ResolvedAutofillStage(
+                    source=source,
+                    lookback_tournaments=getattr(stage, "lookback_tournaments", None),
+                    lookback_days=getattr(stage, "lookback_days", None),
+                )
+            )
+        return resolved
+
+    order = _DEFAULT_STAGE_ORDER_BY_MODE.get(mode or "ow_first", _DEFAULT_STAGE_ORDER_BY_MODE["ow_first"])
+    return [_ResolvedAutofillStage(source=source) for source in order]
+
+
 def _build_priority_rank_data(
-    mode: str,
+    order: Sequence[str],
     signals: _OwRankSignals | None,
     division_history_rank: int | None,
     analytics_rank: int | None,
     grid: DivisionGrid,
 ) -> _RankData | None:
-    """Pick a rank by strict priority fallback over OW / balancer / analytics for the given mode.
+    """Pick a rank by strict priority fallback over the given (enabled, ordered) source chain.
 
-    ``ow_first``       -> [OW (weekly composite), balancer (division history), analytics]
-    ``balancer_first`` -> [balancer, analytics, OW]
-    The first source carrying a value wins (no max blending). Returns ``None`` when every source
-    is empty (the role is then treated as missing).
+    ``order`` lists the enabled sources in priority order (subset of ``ow`` / ``division_history`` /
+    ``analytics``). The first source carrying a value wins (no max blending). Returns ``None`` when
+    no source in ``order`` carries a value (the role is then treated as missing).
     """
     latest_snapshot = signals.latest_snapshot if signals else None
     ow_rank = _map_ow_rank_value(signals.composite_rank_value, grid) if signals else None
@@ -1771,13 +1858,8 @@ def _build_priority_rank_data(
         "division_history": division_history_rank,
         "analytics": analytics_rank,
     }
-    order = (
-        ("division_history", "analytics", "ow")
-        if mode == "balancer_first"
-        else ("ow", "division_history", "analytics")
-    )
 
-    used_source = next((source for source in order if candidates[source] is not None), None)
+    used_source = next((source for source in order if candidates.get(source) is not None), None)
     if used_source is None:
         return None
     chosen = candidates[used_source]
@@ -1814,6 +1896,18 @@ def _map_ow_snapshot_rank(snapshot: models.UserRankSnapshot | Any | None, grid: 
     return _map_ow_rank_value(getattr(snapshot, "rank_value", None), grid)
 
 
+def _autofill_lookback_cutoff(target_number: int | None, lookback_tournaments: int | None) -> int | None:
+    """Min ``Tournament.number`` for a "last N tournaments" window, or None when not applicable.
+
+    Returns ``target_number - lookback_tournaments`` so that tournaments numbered
+    ``[target - N, target)`` (the N immediately preceding the current one, which is excluded
+    elsewhere) qualify. ``None`` when no window is requested or the current tournament has no number.
+    """
+    if lookback_tournaments is None or target_number is None:
+        return None
+    return target_number - lookback_tournaments
+
+
 async def autofill_registration_ranks_from_parsed(
     session: AsyncSession,
     tournament_id: int,
@@ -1821,29 +1915,51 @@ async def autofill_registration_ranks_from_parsed(
     registration_ids: list[int] | None = None,
     overwrite_existing: bool = False,
     add_to_balancer: bool = False,
+    allow_partial: bool = False,
     mode: str = "ow_first",
+    stages: Sequence[Any] | None = None,
     apply: bool = False,
 ) -> dict[str, Any]:
     if registration_ids is not None:
         registration_ids = list(dict.fromkeys(int(registration_id) for registration_id in registration_ids))
 
+    # Resolve the effective, ordered chain of enabled sources (explicit ``stages`` win over ``mode``).
+    resolved_stages = resolve_autofill_stages(mode, stages)
+    order = tuple(stage.source for stage in resolved_stages)
+    enabled_sources = set(order)
+    ow_lookback_days = next((s.lookback_days for s in resolved_stages if s.source == "ow"), None)
+    division_lookback = next(
+        (s.lookback_tournaments for s in resolved_stages if s.source == "division_history"), None
+    )
+    analytics_lookback = next(
+        (s.lookback_tournaments for s in resolved_stages if s.source == "analytics"), None
+    )
+
     now = datetime.now(UTC)
     tournament = await _load_tournament_for_autofill(session, tournament_id)
     grid = DivisionGrid.from_version(tournament.division_grid_version if tournament else None)
+    target_number = getattr(tournament, "number", None) if tournament is not None else None
 
     registrations = await _load_rank_autofill_registrations(session, tournament_id, registration_ids)
     battle_tags_by_key = await _load_main_battle_tags_by_key(session, registrations)
-    ow_signals_by_tag_id = await _load_ow_rank_signals_by_battle_tag_id(
-        session,
-        [battle_tag.id for battle_tag in battle_tags_by_key.values()],
-        now,
-    )
+
+    # Only load a source when its stage is enabled (skips its DB query otherwise). A disabled
+    # source contributes no candidate, so it can never win the priority chain.
+    ow_signals_by_tag_id: dict[int, dict[str, _OwRankSignals]] = {}
+    if "ow" in enabled_sources:
+        ow_week_window = timedelta(days=ow_lookback_days) if ow_lookback_days else OW_RANK_WEEK_WINDOW
+        ow_signals_by_tag_id = await _load_ow_rank_signals_by_battle_tag_id(
+            session,
+            [battle_tag.id for battle_tag in battle_tags_by_key.values()],
+            now,
+            ow_week_window,
+        )
 
     # Balancer history (division_history) and tournament-participation history (analytics) are
     # both candidates in the priority chain, keyed by user_id then registration role code.
     balancer_history_by_user_id: dict[int, dict[str, int]] = {}
     analytics_history_by_user_id: dict[int, dict[str, int]] = {}
-    if tournament is not None:
+    if tournament is not None and ({"division_history", "analytics"} & enabled_sources):
         user_ids = [
             battle_tag.user_id
             for battle_tag in battle_tags_by_key.values()
@@ -1853,22 +1969,26 @@ async def autofill_registration_ranks_from_parsed(
         # tournament's grid. Best-effort: skip when the target version is unknown or the
         # normalizer cannot be built (loaders then fall back to raw ranks).
         normalizer = await _build_autofill_rank_normalizer(session, tournament)
-        balancer_history_by_user_id = await _load_latest_ranks_from_balancer_history(
-            session,
-            user_ids,
-            tournament_id,
-            tournament.workspace_id,
-            normalizer,
-            grid,
-        )
-        analytics_history_by_user_id = await _load_latest_ranks_from_tournament_history(
-            session,
-            user_ids,
-            tournament_id,
-            tournament.workspace_id,
-            normalizer,
-            grid,
-        )
+        if "division_history" in enabled_sources:
+            balancer_history_by_user_id = await _load_latest_ranks_from_balancer_history(
+                session,
+                user_ids,
+                tournament_id,
+                tournament.workspace_id,
+                normalizer,
+                grid,
+                _autofill_lookback_cutoff(target_number, division_lookback),
+            )
+        if "analytics" in enabled_sources:
+            analytics_history_by_user_id = await _load_latest_ranks_from_tournament_history(
+                session,
+                user_ids,
+                tournament_id,
+                tournament.workspace_id,
+                normalizer,
+                grid,
+                _autofill_lookback_cutoff(target_number, analytics_lookback),
+            )
 
     players: list[dict[str, Any]] = []
     applied_registrations = 0
@@ -1890,7 +2010,7 @@ async def autofill_registration_ranks_from_parsed(
         rank_data_by_role: dict[str, _RankData | Any] = {}
         for registration_role, rank_role in RANK_ROLE_BY_REGISTRATION_ROLE.items():
             resolved = _build_priority_rank_data(
-                mode,
+                order,
                 ow_signals_by_role.get(rank_role),
                 balancer_by_role.get(registration_role),
                 analytics_by_role.get(registration_role),
@@ -1904,6 +2024,7 @@ async def autofill_registration_ranks_from_parsed(
             rank_data_by_role,
             battle_tag_linked=main_battle_tag is not None,
             overwrite_existing=overwrite_existing,
+            allow_partial=allow_partial,
             applied=apply,
         )
         will_add_to_balancer, balancer_reason = _rank_autofill_balancer_addition(
@@ -1947,6 +2068,9 @@ async def autofill_registration_ranks_from_parsed(
     updatable_registrations = sum(1 for row in players if row["status"] in {"will_update", "applied"})
     skipped_registrations = sum(1 for row in players if row["status"] == "skipped")
     unchanged_registrations = sum(1 for row in players if row["status"] == "unchanged")
+    unverified_registrations = sum(
+        1 for row in players if any(role.get("action") == "unverified" for role in row["roles"])
+    )
 
     return {
         "total_registrations": len(players),
@@ -1954,6 +2078,7 @@ async def autofill_registration_ranks_from_parsed(
         "applied_registrations": applied_registrations,
         "skipped_registrations": skipped_registrations,
         "unchanged_registrations": unchanged_registrations,
+        "unverified_registrations": unverified_registrations,
         "role_updates": role_updates,
         "overwrite_existing": overwrite_existing,
         "add_to_balancer": add_to_balancer,

--- a/backend/tournament-service/tests/test_registration_rank_autofill.py
+++ b/backend/tournament-service/tests/test_registration_rank_autofill.py
@@ -214,9 +214,14 @@ def _ow_signals(composite: int | None, *, latest_rank: int | None = None) -> Sim
     return reg_admin._OwRankSignals(composite_rank_value=composite, latest_snapshot=latest)
 
 
+# Ordered source chains (what ``resolve_autofill_stages`` produces for the legacy presets).
+_OW_FIRST = ("ow", "division_history", "analytics")
+_BALANCER_FIRST = ("division_history", "analytics", "ow")
+
+
 def test_priority_ow_first_prefers_ow() -> None:
     # User-confirmed example: OW=3000, balancer=3200, analytics=2800 -> ow_first picks OW.
-    data = reg_admin._build_priority_rank_data("ow_first", _ow_signals(3000), 3200, 2800, _FakeGrid())
+    data = reg_admin._build_priority_rank_data(_OW_FIRST, _ow_signals(3000), 3200, 2800, _FakeGrid())
 
     assert data is not None
     assert data.rank_value == 3000
@@ -228,7 +233,7 @@ def test_priority_ow_first_prefers_ow() -> None:
 
 
 def test_priority_balancer_first_prefers_balancer() -> None:
-    data = reg_admin._build_priority_rank_data("balancer_first", _ow_signals(3000), 3200, 2800, _FakeGrid())
+    data = reg_admin._build_priority_rank_data(_BALANCER_FIRST, _ow_signals(3000), 3200, 2800, _FakeGrid())
 
     assert data is not None
     assert data.rank_value == 3200
@@ -237,7 +242,7 @@ def test_priority_balancer_first_prefers_balancer() -> None:
 
 
 def test_priority_ow_first_falls_back_to_balancer() -> None:
-    data = reg_admin._build_priority_rank_data("ow_first", None, 3200, 2800, _FakeGrid())
+    data = reg_admin._build_priority_rank_data(_OW_FIRST, None, 3200, 2800, _FakeGrid())
 
     assert data is not None
     assert data.rank_value == 3200
@@ -245,7 +250,7 @@ def test_priority_ow_first_falls_back_to_balancer() -> None:
 
 
 def test_priority_ow_first_falls_back_to_analytics() -> None:
-    data = reg_admin._build_priority_rank_data("ow_first", None, None, 2800, _FakeGrid())
+    data = reg_admin._build_priority_rank_data(_OW_FIRST, None, None, 2800, _FakeGrid())
 
     assert data is not None
     assert data.rank_value == 2800
@@ -253,7 +258,7 @@ def test_priority_ow_first_falls_back_to_analytics() -> None:
 
 
 def test_priority_balancer_first_prefers_analytics_over_ow() -> None:
-    data = reg_admin._build_priority_rank_data("balancer_first", _ow_signals(3000), None, 2800, _FakeGrid())
+    data = reg_admin._build_priority_rank_data(_BALANCER_FIRST, _ow_signals(3000), None, 2800, _FakeGrid())
 
     assert data is not None
     assert data.rank_value == 2800
@@ -261,7 +266,7 @@ def test_priority_balancer_first_prefers_analytics_over_ow() -> None:
 
 
 def test_priority_balancer_first_falls_back_to_ow_last() -> None:
-    data = reg_admin._build_priority_rank_data("balancer_first", _ow_signals(3000), None, None, _FakeGrid())
+    data = reg_admin._build_priority_rank_data(_BALANCER_FIRST, _ow_signals(3000), None, None, _FakeGrid())
 
     assert data is not None
     assert data.rank_value == 3000
@@ -269,7 +274,7 @@ def test_priority_balancer_first_falls_back_to_ow_last() -> None:
 
 
 def test_priority_unmapped_ow_is_skipped() -> None:
-    data = reg_admin._build_priority_rank_data("ow_first", _ow_signals(5000), 3400, None, _FakeGrid())
+    data = reg_admin._build_priority_rank_data(_OW_FIRST, _ow_signals(5000), 3400, None, _FakeGrid())
 
     assert data is not None
     assert data.rank_value == 3400
@@ -278,12 +283,176 @@ def test_priority_unmapped_ow_is_skipped() -> None:
 
 
 def test_priority_returns_none_when_all_sources_empty() -> None:
-    assert reg_admin._build_priority_rank_data("ow_first", None, None, None, _FakeGrid()) is None
+    assert reg_admin._build_priority_rank_data(_OW_FIRST, None, None, None, _FakeGrid()) is None
     # OW present but unmapped, no balancer/analytics → still nothing usable.
     assert (
-        reg_admin._build_priority_rank_data("balancer_first", _ow_signals(5000), None, None, _FakeGrid())
+        reg_admin._build_priority_rank_data(_BALANCER_FIRST, _ow_signals(5000), None, None, _FakeGrid())
         is None
     )
+
+
+def test_priority_custom_order_analytics_only_ignores_disabled_sources() -> None:
+    # Only analytics in the chain: OW and balancer candidates are present but never considered.
+    data = reg_admin._build_priority_rank_data(("analytics",), _ow_signals(3000), 3200, 2800, _FakeGrid())
+
+    assert data is not None
+    assert data.rank_value == 2800
+    assert data.used_source == "analytics"
+
+
+def test_priority_custom_order_reordered_prefers_first_in_order() -> None:
+    # analytics before division_history → analytics wins even though balancer has a value.
+    data = reg_admin._build_priority_rank_data(
+        ("analytics", "division_history"), None, 3200, 2800, _FakeGrid()
+    )
+
+    assert data is not None
+    assert data.rank_value == 2800
+    assert data.used_source == "analytics"
+
+
+def test_priority_empty_order_returns_none() -> None:
+    assert reg_admin._build_priority_rank_data((), _ow_signals(3000), 3200, 2800, _FakeGrid()) is None
+
+
+# ── resolve_autofill_stages: legacy mode presets vs explicit stage chain ─────────────────────
+
+
+def _stage(source: str, *, enabled: bool = True, lookback_tournaments=None, lookback_days=None):
+    return SimpleNamespace(
+        source=source,
+        enabled=enabled,
+        lookback_tournaments=lookback_tournaments,
+        lookback_days=lookback_days,
+    )
+
+
+def test_resolve_stages_uses_mode_order_when_no_stages() -> None:
+    assert [s.source for s in reg_admin.resolve_autofill_stages("ow_first", None)] == list(_OW_FIRST)
+    assert [s.source for s in reg_admin.resolve_autofill_stages("balancer_first", None)] == list(_BALANCER_FIRST)
+    # Unknown / None mode → ow_first default.
+    assert [s.source for s in reg_admin.resolve_autofill_stages(None, None)] == list(_OW_FIRST)
+
+
+def test_resolve_stages_explicit_chain_overrides_mode_and_preserves_order() -> None:
+    stages = [_stage("analytics", lookback_tournaments=5), _stage("ow", lookback_days=14)]
+    resolved = reg_admin.resolve_autofill_stages("ow_first", stages)
+
+    assert [s.source for s in resolved] == ["analytics", "ow"]
+    assert resolved[0].lookback_tournaments == 5
+    assert resolved[1].lookback_days == 14
+
+
+def test_resolve_stages_drops_disabled_and_dedupes() -> None:
+    stages = [
+        _stage("ow"),
+        _stage("division_history", enabled=False),
+        _stage("ow"),  # duplicate, dropped
+        _stage("analytics"),
+    ]
+    resolved = reg_admin.resolve_autofill_stages("ow_first", stages)
+
+    assert [s.source for s in resolved] == ["ow", "analytics"]
+
+
+def test_resolve_stages_all_disabled_is_empty() -> None:
+    stages = [_stage("ow", enabled=False), _stage("analytics", enabled=False)]
+    assert reg_admin.resolve_autofill_stages("ow_first", stages) == []
+
+
+def test_lookback_cutoff() -> None:
+    assert reg_admin._autofill_lookback_cutoff(42, 5) == 37
+    assert reg_admin._autofill_lookback_cutoff(None, 5) is None
+    assert reg_admin._autofill_lookback_cutoff(42, None) is None
+
+
+# ── allow_partial + unverified action in the plan builder ────────────────────────────────────
+
+
+def test_partial_applies_found_role_and_leaves_unparsed_role_untouched() -> None:
+    tank = _role("tank", priority=0)  # no current rank, no parsed rank → would otherwise block
+    dps = _role("dps", priority=1)  # parsed rank found
+
+    row, updates = reg_admin.build_registration_rank_autofill_plan(
+        _registration(tank, dps),
+        {"damage": _snapshot(3300)},
+        battle_tag_linked=True,
+        overwrite_existing=False,
+        allow_partial=True,
+    )
+
+    assert row["status"] == "will_update"
+    assert row["partial"] is True
+    assert len(updates) == 1
+    assert updates[0][0] is dps
+    assert tank.rank_value is None  # unfilled role left untouched
+    actions = {role_row["role"]: role_row["action"] for role_row in row["roles"]}
+    assert actions == {"tank": "missing_rank", "dps": "set"}
+
+
+def test_partial_preserves_existing_rank_on_unparsed_role() -> None:
+    # Unfound role already has a rank → reported as unverified (kept), never cleared.
+    tank = _role("tank", rank_value=3100, priority=0)
+    dps = _role("dps", priority=1)  # parsed rank found
+
+    row, updates = reg_admin.build_registration_rank_autofill_plan(
+        _registration(tank, dps),
+        {"damage": _snapshot(3300)},
+        battle_tag_linked=True,
+        overwrite_existing=False,
+        allow_partial=True,
+    )
+
+    assert row["status"] == "will_update"
+    assert len(updates) == 1
+    assert updates[0][0] is dps
+    assert tank.rank_value == 3100  # existing rank untouched, never cleared
+    actions = {role_row["role"]: role_row["action"] for role_row in row["roles"]}
+    assert actions["tank"] == "unverified"
+
+
+def test_partial_disabled_skips_whole_registration() -> None:
+    tank = _role("tank", priority=0)  # no current rank, no parsed rank
+    dps = _role("dps", priority=1)
+
+    row, updates = reg_admin.build_registration_rank_autofill_plan(
+        _registration(tank, dps),
+        {"damage": _snapshot(3300)},
+        battle_tag_linked=True,
+        overwrite_existing=False,
+        allow_partial=False,
+    )
+
+    assert updates == []
+    assert row["status"] == "skipped"
+    assert row["partial"] is False
+    assert [role_row["action"] for role_row in row["roles"]] == ["missing_rank", "blocked"]
+
+
+def test_unverified_action_when_existing_rank_has_no_source_value() -> None:
+    # Current rank set, overwrite off, and no source produced a value for the role → unverified.
+    row, updates = reg_admin.build_registration_rank_autofill_plan(
+        _registration(_role("support", rank_value=2100)),
+        {},
+        battle_tag_linked=True,
+        overwrite_existing=False,
+    )
+
+    assert updates == []
+    assert row["status"] == "unchanged"
+    assert row["roles"][0]["action"] == "unverified"
+
+
+def test_keep_existing_action_when_source_value_present() -> None:
+    # Same setup but a source value exists → kept (not unverified) because overwrite is off.
+    row, _updates = reg_admin.build_registration_rank_autofill_plan(
+        _registration(_role("support", rank_value=2100)),
+        {"support": _snapshot(2500, role="support")},
+        battle_tag_linked=True,
+        overwrite_existing=False,
+    )
+
+    assert row["roles"][0]["action"] == "keep_existing"
 
 
 # ── OW weekly composite: round((max + mean) / 2) over a 7-day window ─────────────────────────

--- a/frontend/src/app/balancer/components/rank-autofill-stages.test.ts
+++ b/frontend/src/app/balancer/components/rank-autofill-stages.test.ts
@@ -1,0 +1,89 @@
+import {
+  defaultRankAutofillStages,
+  moveStage,
+  moveStageBySource,
+  parseLookbackInput,
+  setStageEnabled,
+  setStageLookback,
+  stageWindowValue
+} from "./rank-autofill-stages";
+
+type TestFunction = () => void | Promise<void>;
+type Expectation<T> = {
+  toBe: (expected: T) => void;
+  toEqual: (expected: unknown) => void;
+};
+
+declare const describe: (name: string, fn: TestFunction) => void;
+declare const it: (name: string, fn: TestFunction) => void;
+declare const expect: <T>(actual: T) => Expectation<T>;
+
+describe("rank autofill stage helpers", () => {
+  it("builds the default chain ow → division_history → analytics, all enabled", () => {
+    expect(defaultRankAutofillStages().map((stage) => stage.source)).toEqual([
+      "ow",
+      "division_history",
+      "analytics"
+    ]);
+    expect(defaultRankAutofillStages().every((stage) => stage.enabled)).toBe(true);
+  });
+
+  it("returns a fresh default array each call", () => {
+    expect(defaultRankAutofillStages() === defaultRankAutofillStages()).toBe(false);
+  });
+
+  it("moves a stage to a new index immutably", () => {
+    const stages = defaultRankAutofillStages();
+    const moved = moveStage(stages, 0, 2);
+    expect(moved.map((stage) => stage.source)).toEqual(["division_history", "analytics", "ow"]);
+    // original untouched
+    expect(stages.map((stage) => stage.source)).toEqual(["ow", "division_history", "analytics"]);
+  });
+
+  it("returns the same reference on a no-op move", () => {
+    const stages = defaultRankAutofillStages();
+    expect(moveStage(stages, 1, 1) === stages).toBe(true);
+    expect(moveStage(stages, 0, 9) === stages).toBe(true);
+  });
+
+  it("reorders by source ids", () => {
+    const stages = defaultRankAutofillStages();
+    const moved = moveStageBySource(stages, "analytics", "ow");
+    expect(moved.map((stage) => stage.source)).toEqual(["analytics", "ow", "division_history"]);
+  });
+
+  it("toggles only the targeted stage", () => {
+    const stages = defaultRankAutofillStages();
+    const next = setStageEnabled(stages, "ow", false);
+    expect(next.find((stage) => stage.source === "ow")?.enabled).toBe(false);
+    expect(next.find((stage) => stage.source === "analytics")?.enabled).toBe(true);
+    // original untouched
+    expect(stages.find((stage) => stage.source === "ow")?.enabled).toBe(true);
+  });
+
+  it("writes lookback to the field matching the window kind", () => {
+    const stages = defaultRankAutofillStages();
+    const withDays = setStageLookback(stages, "ow", 14);
+    expect(withDays.find((stage) => stage.source === "ow")?.lookback_days).toBe(14);
+
+    const withTournaments = setStageLookback(stages, "analytics", 5);
+    expect(withTournaments.find((stage) => stage.source === "analytics")?.lookback_tournaments).toBe(5);
+  });
+
+  it("reads the active window value regardless of backing field", () => {
+    const stages = setStageLookback(setStageLookback(defaultRankAutofillStages(), "ow", 10), "analytics", 5);
+    expect(stageWindowValue(stages[0])).toBe(10);
+    expect(stageWindowValue(stages[2])).toBe(5);
+    expect(stageWindowValue(stages[1])).toBe(null);
+  });
+
+  it("parses lookback input, treating empty / invalid / < 1 as no limit", () => {
+    expect(parseLookbackInput("5")).toBe(5);
+    expect(parseLookbackInput("  7 ")).toBe(7);
+    expect(parseLookbackInput("3.9")).toBe(3);
+    expect(parseLookbackInput("")).toBe(null);
+    expect(parseLookbackInput("0")).toBe(null);
+    expect(parseLookbackInput("-2")).toBe(null);
+    expect(parseLookbackInput("abc")).toBe(null);
+  });
+});

--- a/frontend/src/app/balancer/components/rank-autofill-stages.ts
+++ b/frontend/src/app/balancer/components/rank-autofill-stages.ts
@@ -1,0 +1,128 @@
+import type {
+  RankAutofillSourceKey,
+  RegistrationRankAutofillStage,
+} from "@/types/balancer-admin.types";
+
+/** Lookback window unit for a stage: tournament-based sources vs the time-based OW source. */
+export type StageWindowKind = "tournaments" | "days";
+
+export interface RankAutofillStageMeta {
+  source: RankAutofillSourceKey;
+  label: string;
+  description: string;
+  windowKind: StageWindowKind;
+  /** Short unit suffix shown next to the window input. */
+  windowSuffix: string;
+  /** Placeholder shown when no window is set. */
+  windowPlaceholder: string;
+}
+
+export const STAGE_META: Record<RankAutofillSourceKey, RankAutofillStageMeta> = {
+  ow: {
+    source: "ow",
+    label: "Overwatch rank",
+    description: "Недельный композит снапшотов OW по главному BattleTag.",
+    windowKind: "days",
+    windowSuffix: "дн.",
+    windowPlaceholder: "7"
+  },
+  division_history: {
+    source: "division_history",
+    label: "История balancer",
+    description: "Последний ранг из прошлых balancer-регистраций.",
+    windowKind: "tournaments",
+    windowSuffix: "турн.",
+    windowPlaceholder: "все"
+  },
+  analytics: {
+    source: "analytics",
+    label: "Аналитика",
+    description: "Последний ранг из участия в прошлых турнирах.",
+    windowKind: "tournaments",
+    windowSuffix: "турн.",
+    windowPlaceholder: "все"
+  }
+};
+
+/** Default chain: OW → история balancer → аналитика, все включены, без окон. */
+export function defaultRankAutofillStages(): RegistrationRankAutofillStage[] {
+  return [
+    { source: "ow", enabled: true, lookback_days: null },
+    { source: "division_history", enabled: true, lookback_tournaments: null },
+    { source: "analytics", enabled: true, lookback_tournaments: null }
+  ];
+}
+
+/** Move a stage from one index to another, returning a new array (or the same ref on no-op). */
+export function moveStage(
+  stages: RegistrationRankAutofillStage[],
+  from: number,
+  to: number
+): RegistrationRankAutofillStage[] {
+  if (from === to || from < 0 || to < 0 || from >= stages.length || to >= stages.length) {
+    return stages;
+  }
+  const next = [...stages];
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}
+
+/** Reorder by source ids (convenient for drag-and-drop where ids, not indices, are known). */
+export function moveStageBySource(
+  stages: RegistrationRankAutofillStage[],
+  activeSource: RankAutofillSourceKey,
+  overSource: RankAutofillSourceKey
+): RegistrationRankAutofillStage[] {
+  const from = stages.findIndex((stage) => stage.source === activeSource);
+  const to = stages.findIndex((stage) => stage.source === overSource);
+  if (from === -1 || to === -1) {
+    return stages;
+  }
+  return moveStage(stages, from, to);
+}
+
+/** Toggle the enabled flag of a single stage immutably. */
+export function setStageEnabled(
+  stages: RegistrationRankAutofillStage[],
+  source: RankAutofillSourceKey,
+  enabled: boolean
+): RegistrationRankAutofillStage[] {
+  return stages.map((stage) => (stage.source === source ? { ...stage, enabled } : stage));
+}
+
+/** Set the lookback window for a stage, writing to the field that matches its window kind. */
+export function setStageLookback(
+  stages: RegistrationRankAutofillStage[],
+  source: RankAutofillSourceKey,
+  value: number | null
+): RegistrationRankAutofillStage[] {
+  return stages.map((stage) => {
+    if (stage.source !== source) {
+      return stage;
+    }
+    return STAGE_META[source].windowKind === "days"
+      ? { ...stage, lookback_days: value }
+      : { ...stage, lookback_tournaments: value };
+  });
+}
+
+/** Current lookback value for a stage, regardless of which field backs it. */
+export function stageWindowValue(stage: RegistrationRankAutofillStage): number | null {
+  const value =
+    STAGE_META[stage.source].windowKind === "days" ? stage.lookback_days : stage.lookback_tournaments;
+  return value ?? null;
+}
+
+/** Parse a raw window input: empty / invalid / < 1 → null (no limit); otherwise a positive integer. */
+export function parseLookbackInput(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return null;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return null;
+  }
+  return Math.floor(parsed);
+}

--- a/frontend/src/app/balancer/registrations/page.tsx
+++ b/frontend/src/app/balancer/registrations/page.tsx
@@ -48,8 +48,6 @@ import { useBalancerTournamentId } from "@/app/balancer/components/useBalancerTo
 import BalancerRegistrationsColumnPicker from "@/app/balancer/registrations/_components/BalancerRegistrationsColumnPicker";
 import RegistrationRowActions from "@/app/balancer/registrations/_components/RegistrationRowActions";
 import BattleTagRankHistory from "@/components/BattleTagRankHistory";
-import PlayerDivisionIcon from "@/components/PlayerDivisionIcon";
-import PlayerRoleIcon from "@/components/PlayerRoleIcon";
 import {
   type BalancerRegistrationColumnDefinition,
   buildBalancerRegistrationColumns
@@ -92,21 +90,16 @@ import {
 } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import { useColumnVisibility } from "@/hooks/useColumnVisibility";
-import { useDivisionGrid } from "@/hooks/useCurrentWorkspace";
 import { mergeStatusOptions } from "@/lib/balancer-statuses";
 import { notify } from "@/lib/notify";
-import { resolveDivisionFromRank } from "@/lib/division-grid";
-import { ROLE_LABELS, getRoleIconName, getSubroleLabel } from "@/lib/roles";
+import { ROLE_LABELS, getSubroleLabel } from "@/lib/roles";
 import balancerAdminService from "@/services/balancer-admin.service";
 import registrationService from "@/services/registration.service";
 import type {
   AdminRegistration,
   AdminRegistrationRole,
   BalancerRoleCode,
-  BalancerRoleSubtype,
-  RegistrationRankAutofillMode,
-  RegistrationRankAutofillResponse,
-  RegistrationRankAutofillRole
+  BalancerRoleSubtype
 } from "@/types/balancer-admin.types";
 import type { RegistrationForm, SubroleCatalog } from "@/types/registration.types";
 import { cn } from "@/lib/utils";
@@ -115,11 +108,6 @@ import { useWorkspaceStore } from "@/stores/workspace.store";
 type RegistrationStatusFilter = string;
 type InclusionFilter = "all" | "included" | "excluded";
 type SourceFilter = "all" | "manual" | "google_sheets";
-type RankAutofillPreviewOptions = {
-  overwriteExisting: boolean;
-  addToBalancer: boolean;
-  mode: RegistrationRankAutofillMode;
-};
 
 const RESPONSIVE_CLASS: Record<
   NonNullable<BalancerRegistrationColumnDefinition["responsive"]>,
@@ -250,454 +238,6 @@ function CheckInBadge({ registration }: { registration: AdminRegistration }) {
   );
 }
 
-function formatRankSource(role: RegistrationRankAutofillRole): string {
-  const nativeRank = role.division
-    ? `${role.division}${role.tier != null ? ` ${role.tier}` : ""}`
-    : null;
-  const capturedAt = role.captured_at ? formatSubmittedAt(role.captured_at) : null;
-  return [role.platform?.toUpperCase(), nativeRank, capturedAt].filter(Boolean).join(" / ");
-}
-
-/**
- * Per-role breakdown of the blended suggestion: division history + OW peak (current season) +
- * OW current, with the chosen signal marked. Lines with no value are omitted.
- */
-function formatBlendBreakdown(role: RegistrationRankAutofillRole): string[] {
-  const mark = (source: RegistrationRankAutofillRole["used_source"]) =>
-    role.used_source === source ? " ← used" : "";
-  const lines: string[] = [];
-  if (role.ow_rank_value != null) {
-    lines.push(`OW (week) ${role.ow_rank_value}${mark("ow")}`);
-  }
-  if (role.division_history_rank_value != null) {
-    lines.push(`balancer ${role.division_history_rank_value}${mark("division_history")}`);
-  }
-  if (role.analytics_rank_value != null) {
-    lines.push(`analytics ${role.analytics_rank_value}${mark("analytics")}`);
-  }
-  return lines;
-}
-
-function RankAutofillRolePill({ role }: { role: RegistrationRankAutofillRole }) {
-  const grid = useDivisionGrid();
-  const roleLabel = ROLE_LABELS[role.role] ?? role.role;
-  const source = formatRankSource(role);
-  const breakdown = formatBlendBreakdown(role);
-  const isUpdate = role.action === "set" || role.action === "overwrite";
-  const isBlocked = role.action === "blocked" || role.action === "missing_rank";
-  const isMissing = role.action === "missing_rank";
-
-  const parsedDivision =
-    role.parsed_rank_value != null ? resolveDivisionFromRank(grid, role.parsed_rank_value) : null;
-  const currentDivision =
-    role.current_rank_value != null ? resolveDivisionFromRank(grid, role.current_rank_value) : null;
-
-  // Which rank value to show as the primary label
-  const primaryRank = isUpdate
-    ? role.parsed_rank_value
-    : (role.current_rank_value ?? role.parsed_rank_value);
-  const primaryDivision = isUpdate ? parsedDivision : (currentDivision ?? parsedDivision);
-
-  return (
-    <div
-      className={cn(
-        "inline-flex min-w-0 items-center gap-1.5 rounded-md border px-2 py-1 text-[11px]",
-        isUpdate
-          ? "border-emerald-400/25 bg-emerald-500/10 text-emerald-100"
-          : isBlocked
-            ? "border-orange-400/25 bg-orange-500/10 text-orange-100"
-            : "border-white/10 bg-white/5 text-white/60"
-      )}
-      title={[[role.reason, source].filter(Boolean).join(" / "), ...breakdown]
-        .filter(Boolean)
-        .join("\n")}
-    >
-      <span className="shrink-0" aria-hidden="true">
-        <PlayerRoleIcon role={getRoleIconName(role.role)} size={14} color="currentColor" />
-      </span>
-      <span className="sr-only">{roleLabel}</span>
-
-      {isMissing ? (
-        <span className="opacity-60">missing</span>
-      ) : (
-        <>
-          {/* When overwriting: show current → new */}
-          {isUpdate && role.current_rank_value != null && (
-            <>
-              {currentDivision != null && (
-                <PlayerDivisionIcon division={currentDivision} width={16} height={16} />
-              )}
-              <span className="tabular-nums opacity-50">{role.current_rank_value}</span>
-              <span className="opacity-40">→</span>
-            </>
-          )}
-          {primaryDivision != null && (
-            <PlayerDivisionIcon division={primaryDivision} width={16} height={16} />
-          )}
-          <span className="tabular-nums">{primaryRank ?? "-"}</span>
-        </>
-      )}
-    </div>
-  );
-}
-
-function RankAutofillDialog({
-  open,
-  onOpenChange,
-  preview,
-  loadingPreview,
-  applying,
-  mode,
-  onModeChange,
-  overwriteExisting,
-  onOverwriteChange,
-  addToBalancer,
-  onAddToBalancerChange,
-  assignmentConfirmed,
-  onAssignmentConfirmedChange,
-  onApply
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  preview: RegistrationRankAutofillResponse | undefined;
-  loadingPreview: boolean;
-  applying: boolean;
-  mode: RegistrationRankAutofillMode;
-  onModeChange: (mode: RegistrationRankAutofillMode) => void;
-  overwriteExisting: boolean;
-  onOverwriteChange: (checked: boolean) => void;
-  addToBalancer: boolean;
-  onAddToBalancerChange: (checked: boolean) => void;
-  assignmentConfirmed: boolean;
-  onAssignmentConfirmedChange: (checked: boolean) => void;
-  onApply: () => void;
-}) {
-  const updatablePlayers =
-    preview?.players.filter(
-      (player) => player.status === "will_update" || player.status === "applied"
-    ) ?? [];
-  const skippedPlayers = preview?.players.filter((player) => player.status === "skipped") ?? [];
-  const unchangedPlayers = preview?.players.filter((player) => player.status === "unchanged") ?? [];
-
-  const isApplyDisabled =
-    !preview ||
-    (preview.role_updates === 0 && preview.balancer_additions === 0) ||
-    !assignmentConfirmed ||
-    loadingPreview ||
-    applying;
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col gap-0 overflow-hidden border-border bg-popover p-0 text-white shadow-2xl shadow-black/50 sm:rounded-xl">
-        {/* ── Header ── */}
-        <DialogHeader className="shrink-0 border-b border-white/10 px-5 py-3.5 text-left">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <DialogTitle className="text-lg font-semibold tracking-tight text-white">
-                Autofill parsed ranks
-              </DialogTitle>
-              <DialogDescription className="mt-0.5 text-xs text-white/40">
-                Priority fallback per role. Main BattleTag only.
-              </DialogDescription>
-            </div>
-            {/* Stats strip — visible once preview loads */}
-            {preview && !loadingPreview && (
-              <div className="flex shrink-0 items-center divide-x divide-white/10 rounded-lg border border-white/10 bg-white/[0.03]">
-                {[
-                  { label: "Players", value: preview.total_registrations, color: "" },
-                  {
-                    label: "Update",
-                    value: preview.updatable_registrations,
-                    color: "text-emerald-300"
-                  },
-                  { label: "Ranks", value: preview.role_updates, color: "text-emerald-300" },
-                  {
-                    label: "→ Balancer",
-                    value: preview.balancer_additions,
-                    color: "text-cyan-300"
-                  },
-                  {
-                    label: "Skipped",
-                    value: preview.skipped_registrations,
-                    color: preview.skipped_registrations > 0 ? "text-orange-300" : ""
-                  }
-                ].map(({ label, value, color }) => (
-                  <div key={label} className="px-3 py-2 text-center">
-                    <div className="text-[10px] font-semibold uppercase tracking-wider text-white/35">
-                      {label}
-                    </div>
-                    <div
-                      className={cn(
-                        "text-base font-semibold tabular-nums",
-                        color || "text-white/80"
-                      )}
-                    >
-                      {value}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        </DialogHeader>
-
-        {/* ── Settings strip ── */}
-        <div className="shrink-0 border-b border-white/10 bg-white/[0.02] px-5 py-2.5">
-          <div className="flex flex-wrap items-center gap-3">
-            {/* Source priority mode */}
-            <div className="flex rounded-lg border border-white/10 p-0.5">
-              {(
-                [
-                  { value: "ow_first", label: "OW → balancer → analytics" },
-                  { value: "balancer_first", label: "Balancer → analytics → OW" }
-                ] as { value: RegistrationRankAutofillMode; label: string }[]
-              ).map(({ value, label }) => (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => onModeChange(value)}
-                  disabled={loadingPreview || applying}
-                  className={cn(
-                    "rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50",
-                    mode === value
-                      ? "bg-indigo-500/20 text-indigo-200"
-                      : "text-white/50 hover:text-white/80"
-                  )}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-
-            <div className="h-5 w-px bg-white/10" aria-hidden="true" />
-
-            {/* Overwrite checkbox */}
-            <label className="flex cursor-pointer items-center gap-2">
-              <Checkbox
-                checked={overwriteExisting}
-                onCheckedChange={(checked) => onOverwriteChange(checked === true)}
-                disabled={loadingPreview || applying}
-                aria-label="Overwrite existing ranks"
-              />
-              <span className="text-xs text-white/65 select-none">Overwrite existing ranks</span>
-            </label>
-
-            {/* Add to balancer checkbox */}
-            <label className="flex cursor-pointer items-center gap-2">
-              <Checkbox
-                checked={addToBalancer}
-                onCheckedChange={(checked) => onAddToBalancerChange(checked === true)}
-                disabled={loadingPreview || applying}
-                aria-label="Move eligible players to balancer"
-              />
-              <span className="text-xs text-white/65 select-none">Move eligible to balancer</span>
-            </label>
-
-            {loadingPreview && (
-              <div className="ml-auto flex items-center gap-1.5 text-xs text-white/40">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                Loading preview…
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* ── Scrollable content ── */}
-        <div className="min-h-0 flex-1 overflow-y-auto">
-          {!preview && !loadingPreview ? (
-            <div className="flex h-32 items-center justify-center text-sm text-white/30">
-              Preview is not loaded.
-            </div>
-          ) : preview ? (
-            <div className="divide-y divide-white/[0.06]">
-              {/* Will be assigned */}
-              <div className="px-5 py-3">
-                <div className="mb-2 flex items-center gap-2">
-                  <span className="text-[11px] font-semibold uppercase tracking-wider text-white/40">
-                    Will be assigned
-                  </span>
-                  <span className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-300">
-                    {updatablePlayers.length}
-                  </span>
-                </div>
-                {updatablePlayers.length === 0 ? (
-                  <p className="text-xs text-white/30">No ranks to update.</p>
-                ) : (
-                  <div className="overflow-hidden rounded-xl border border-white/10">
-                    {updatablePlayers.map((player) => (
-                      <div
-                        key={player.registration_id}
-                        className="flex min-w-0 items-center gap-3 border-b border-white/[0.06] px-3 py-2 last:border-b-0"
-                      >
-                        <div className="min-w-0 w-48 shrink-0">
-                          <div className="truncate text-sm font-medium text-white/85">
-                            {player.battle_tag ??
-                              player.display_name ??
-                              `#${player.registration_id}`}
-                          </div>
-                          <div className="flex items-center gap-1.5 text-[11px] text-white/30">
-                            <span>#{player.registration_id}</span>
-                            {player.will_add_to_balancer && (
-                              <span className="rounded border border-cyan-400/20 bg-cyan-500/10 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-cyan-200">
-                                → Balancer
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                        <div className="flex min-w-0 flex-wrap gap-1.5">
-                          {player.roles
-                            .filter((r) => r.action === "set" || r.action === "overwrite")
-                            .map((role) => (
-                              <RankAutofillRolePill key={role.role} role={role} />
-                            ))}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              {/* Skipped + Already set — side by side */}
-              <div className="grid gap-px lg:grid-cols-2">
-                {/* Skipped */}
-                <div className="px-5 py-3">
-                  <div className="mb-2 flex items-center gap-2">
-                    <span className="text-[11px] font-semibold uppercase tracking-wider text-white/40">
-                      Skipped
-                    </span>
-                    {skippedPlayers.length > 0 && (
-                      <span className="rounded-full bg-orange-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-orange-300">
-                        {skippedPlayers.length}
-                      </span>
-                    )}
-                  </div>
-                  {skippedPlayers.length === 0 ? (
-                    <p className="text-xs text-white/30">None skipped.</p>
-                  ) : (
-                    <div className="max-h-52 overflow-y-auto rounded-xl border border-white/10">
-                      {skippedPlayers.map((player) => (
-                        <div
-                          key={player.registration_id}
-                          className="border-b border-white/[0.06] px-3 py-2 last:border-b-0"
-                        >
-                          <div className="truncate text-xs font-medium text-white/75">
-                            {player.battle_tag ??
-                              player.display_name ??
-                              `#${player.registration_id}`}
-                          </div>
-                          <div className="mt-0.5 text-[11px] leading-4 text-orange-200/70">
-                            {player.reason ?? "Skipped"}
-                          </div>
-                          {player.will_add_to_balancer ? (
-                            <div className="mt-0.5 text-[11px] text-cyan-200/70">
-                              Will be moved to balancer.
-                            </div>
-                          ) : player.balancer_reason ? (
-                            <div className="mt-0.5 text-[11px] text-white/30">
-                              {player.balancer_reason}
-                            </div>
-                          ) : null}
-                          <div className="mt-1.5 flex flex-wrap gap-1">
-                            {player.roles.map((role) => (
-                              <RankAutofillRolePill key={role.role} role={role} />
-                            ))}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-
-                {/* Already set */}
-                <div className="px-5 py-3 lg:border-l lg:border-white/[0.06]">
-                  <div className="mb-2 flex items-center gap-2">
-                    <span className="text-[11px] font-semibold uppercase tracking-wider text-white/40">
-                      Already set
-                    </span>
-                    {unchangedPlayers.length > 0 && (
-                      <span className="rounded-full bg-white/10 px-1.5 py-0.5 text-[10px] font-semibold text-white/40">
-                        {unchangedPlayers.length}
-                      </span>
-                    )}
-                  </div>
-                  {unchangedPlayers.length === 0 ? (
-                    <p className="text-xs text-white/30">No unchanged registrations.</p>
-                  ) : (
-                    <div className="max-h-52 overflow-y-auto rounded-xl border border-white/10">
-                      {unchangedPlayers.map((player) => (
-                        <div
-                          key={player.registration_id}
-                          className="border-b border-white/[0.06] px-3 py-2 last:border-b-0"
-                        >
-                          <div className="truncate text-xs font-medium text-white/75">
-                            {player.battle_tag ??
-                              player.display_name ??
-                              `#${player.registration_id}`}
-                          </div>
-                          <div className="mt-0.5 text-[11px] leading-4 text-white/35">
-                            {player.reason ?? "No rank changes needed."}
-                          </div>
-                          {player.will_add_to_balancer ? (
-                            <div className="mt-0.5 text-[11px] text-cyan-200/70">
-                              Will be moved to balancer.
-                            </div>
-                          ) : player.balancer_reason ? (
-                            <div className="mt-0.5 text-[11px] text-white/30">
-                              {player.balancer_reason}
-                            </div>
-                          ) : null}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          ) : null}
-        </div>
-
-        {/* ── Footer ── */}
-        <div className="shrink-0 border-t border-white/10 px-5 py-3">
-          <div className="flex items-center gap-3">
-            <label className="flex flex-1 cursor-pointer items-center gap-2.5">
-              <Checkbox
-                checked={assignmentConfirmed}
-                onCheckedChange={(checked) => onAssignmentConfirmedChange(checked === true)}
-                disabled={
-                  !preview ||
-                  (preview.role_updates === 0 && preview.balancer_additions === 0) ||
-                  loadingPreview ||
-                  applying
-                }
-                aria-label="Confirm rank assignment"
-              />
-              <span className="text-xs text-white/60 select-none">
-                Confirm assigning ranks to listed players
-              </span>
-            </label>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onOpenChange(false)}
-              disabled={applying}
-            >
-              Cancel
-            </Button>
-            <Button size="sm" onClick={onApply} disabled={isApplyDisabled}>
-              {applying ? (
-                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Check className="mr-1.5 h-3.5 w-3.5" />
-              )}
-              Apply ranks
-            </Button>
-          </div>
-        </div>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
 export default function BalancerRegistrationsPage() {
   const tournamentId = useBalancerTournamentId();
   const queryClient = useQueryClient();
@@ -719,11 +259,6 @@ export default function BalancerRegistrationsPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editingRegistration, setEditingRegistration] = useState<AdminRegistration | null>(null);
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
-  const [rankAutofillOpen, setRankAutofillOpen] = useState(false);
-  const [autofillMode, setAutofillMode] = useState<RegistrationRankAutofillMode>("ow_first");
-  const [overwriteExistingRanks, setOverwriteExistingRanks] = useState(false);
-  const [addAutofilledPlayersToBalancer, setAddAutofilledPlayersToBalancer] = useState(false);
-  const [rankAutofillConfirmed, setRankAutofillConfirmed] = useState(false);
 
   const toggleExpanded = (registrationId: number) =>
     setExpandedIds((current) => {
@@ -943,90 +478,6 @@ export default function BalancerRegistrationsPage() {
     }
   });
 
-  const rankAutofillPreviewMutation = useMutation({
-    mutationFn: ({ overwriteExisting, addToBalancer, mode }: RankAutofillPreviewOptions) => {
-      if (!tournamentId) {
-        throw new Error("Select a tournament first");
-      }
-      return balancerAdminService.previewRegistrationRankAutofill(tournamentId, {
-        overwrite_existing: overwriteExisting,
-        add_to_balancer: addToBalancer,
-        mode
-      });
-    },
-    onSuccess: () => {
-      setRankAutofillConfirmed(false);
-      setRankAutofillOpen(true);
-    }
-  });
-
-  const rankAutofillApplyMutation = useMutation({
-    mutationFn: () => {
-      if (!tournamentId) {
-        throw new Error("Select a tournament first");
-      }
-      return balancerAdminService.applyRegistrationRankAutofill(tournamentId, {
-        overwrite_existing: overwriteExistingRanks,
-        add_to_balancer: addAutofilledPlayersToBalancer,
-        mode: autofillMode
-      });
-    },
-    onSuccess: async (result) => {
-      await invalidateRegistrations();
-      setRankAutofillOpen(false);
-      notify.success("Ranks autofilled", {
-        description:
-          `${result.applied_registrations} player${
-            result.applied_registrations === 1 ? "" : "s"
-          }, ${result.role_updates} role rank${
-            result.role_updates === 1 ? "" : "s"
-          } updated. ${result.skipped_registrations} skipped.` +
-          (result.balancer_additions > 0 ? ` ${result.balancer_additions} moved to balancer.` : "")
-      });
-    }
-  });
-
-  const openRankAutofillPreview = () => {
-    setOverwriteExistingRanks(false);
-    setAddAutofilledPlayersToBalancer(false);
-    setRankAutofillConfirmed(false);
-    rankAutofillPreviewMutation.mutate({
-      overwriteExisting: false,
-      addToBalancer: false,
-      mode: autofillMode
-    });
-  };
-
-  const handleAutofillModeChange = (mode: RegistrationRankAutofillMode) => {
-    setAutofillMode(mode);
-    setRankAutofillConfirmed(false);
-    rankAutofillPreviewMutation.mutate({
-      overwriteExisting: overwriteExistingRanks,
-      addToBalancer: addAutofilledPlayersToBalancer,
-      mode
-    });
-  };
-
-  const handleRankOverwriteChange = (checked: boolean) => {
-    setOverwriteExistingRanks(checked);
-    setRankAutofillConfirmed(false);
-    rankAutofillPreviewMutation.mutate({
-      overwriteExisting: checked,
-      addToBalancer: addAutofilledPlayersToBalancer,
-      mode: autofillMode
-    });
-  };
-
-  const handleAddToBalancerChange = (checked: boolean) => {
-    setAddAutofilledPlayersToBalancer(checked);
-    setRankAutofillConfirmed(false);
-    rankAutofillPreviewMutation.mutate({
-      overwriteExisting: overwriteExistingRanks,
-      addToBalancer: checked,
-      mode: autofillMode
-    });
-  };
-
   const registrations = registrationsQuery.data ?? [];
   const filteredRegistrations = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
@@ -1182,19 +633,17 @@ export default function BalancerRegistrationsPage() {
               </CardDescription>
             </div>
             <div className="flex flex-wrap gap-2">
-              <Button
-                variant="outline"
-                onClick={openRankAutofillPreview}
-                disabled={
-                  rankAutofillPreviewMutation.isPending || rankAutofillApplyMutation.isPending
-                }
-              >
-                {rankAutofillPreviewMutation.isPending ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
+              <Button variant="outline" asChild>
+                <Link
+                  href={
+                    searchParams.toString()
+                      ? `/balancer/registrations/rank-autofill?${searchParams.toString()}`
+                      : "/balancer/registrations/rank-autofill"
+                  }
+                >
                   <Sparkles className="mr-2 h-4 w-4" />
-                )}
-                Autofill ranks
+                  Autofill ranks
+                </Link>
               </Button>
               <Button
                 variant="outline"
@@ -1757,23 +1206,6 @@ export default function BalancerRegistrationsPage() {
           </div>
         </CardContent>
       </Card>
-
-      <RankAutofillDialog
-        open={rankAutofillOpen}
-        onOpenChange={setRankAutofillOpen}
-        preview={rankAutofillPreviewMutation.data}
-        loadingPreview={rankAutofillPreviewMutation.isPending}
-        applying={rankAutofillApplyMutation.isPending}
-        mode={autofillMode}
-        onModeChange={handleAutofillModeChange}
-        overwriteExisting={overwriteExistingRanks}
-        onOverwriteChange={handleRankOverwriteChange}
-        addToBalancer={addAutofilledPlayersToBalancer}
-        onAddToBalancerChange={handleAddToBalancerChange}
-        assignmentConfirmed={rankAutofillConfirmed}
-        onAssignmentConfirmedChange={setRankAutofillConfirmed}
-        onApply={() => rankAutofillApplyMutation.mutate()}
-      />
 
       <Dialog
         open={createOpen}

--- a/frontend/src/app/balancer/registrations/rank-autofill/_components/RankAutofillPreviewTables.tsx
+++ b/frontend/src/app/balancer/registrations/rank-autofill/_components/RankAutofillPreviewTables.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import PlayerDivisionIcon from "@/components/PlayerDivisionIcon";
+import PlayerRoleIcon from "@/components/PlayerRoleIcon";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useDivisionGrid } from "@/hooks/useCurrentWorkspace";
+import { resolveDivisionFromRank } from "@/lib/division-grid";
+import { ROLE_LABELS, getRoleIconName } from "@/lib/roles";
+import { cn } from "@/lib/utils";
+import type {
+  RegistrationRankAutofillPlayer,
+  RegistrationRankAutofillResponse,
+  RegistrationRankAutofillRole
+} from "@/types/balancer-admin.types";
+
+function formatCapturedAt(value: string | null | undefined): string {
+  if (!value) return "-";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "-" : date.toLocaleString();
+}
+
+function formatRankSource(role: RegistrationRankAutofillRole): string {
+  const nativeRank = role.division
+    ? `${role.division}${role.tier != null ? ` ${role.tier}` : ""}`
+    : null;
+  const capturedAt = role.captured_at ? formatCapturedAt(role.captured_at) : null;
+  return [role.platform?.toUpperCase(), nativeRank, capturedAt].filter(Boolean).join(" / ");
+}
+
+/**
+ * Per-role breakdown of the suggestion: OW (week composite), balancer (division history) and
+ * analytics, with the chosen signal marked. Lines with no value are omitted.
+ */
+function formatBlendBreakdown(role: RegistrationRankAutofillRole): string[] {
+  const mark = (source: RegistrationRankAutofillRole["used_source"]) =>
+    role.used_source === source ? " ← used" : "";
+  const lines: string[] = [];
+  if (role.ow_rank_value != null) {
+    lines.push(`OW (week) ${role.ow_rank_value}${mark("ow")}`);
+  }
+  if (role.division_history_rank_value != null) {
+    lines.push(`balancer ${role.division_history_rank_value}${mark("division_history")}`);
+  }
+  if (role.analytics_rank_value != null) {
+    lines.push(`analytics ${role.analytics_rank_value}${mark("analytics")}`);
+  }
+  return lines;
+}
+
+export function RankAutofillRolePill({ role }: { role: RegistrationRankAutofillRole }) {
+  const grid = useDivisionGrid();
+  const roleLabel = ROLE_LABELS[role.role] ?? role.role;
+  const source = formatRankSource(role);
+  const breakdown = formatBlendBreakdown(role);
+  const isUpdate = role.action === "set" || role.action === "overwrite";
+  const isUnverified = role.action === "unverified";
+  const isBlocked = role.action === "blocked" || role.action === "missing_rank";
+  const isMissing = role.action === "missing_rank";
+
+  const parsedDivision =
+    role.parsed_rank_value != null ? resolveDivisionFromRank(grid, role.parsed_rank_value) : null;
+  const currentDivision =
+    role.current_rank_value != null ? resolveDivisionFromRank(grid, role.current_rank_value) : null;
+
+  const primaryRank = isUpdate
+    ? role.parsed_rank_value
+    : (role.current_rank_value ?? role.parsed_rank_value);
+  const primaryDivision = isUpdate ? parsedDivision : (currentDivision ?? parsedDivision);
+
+  return (
+    <div
+      className={cn(
+        "inline-flex min-w-0 items-center gap-1.5 rounded-md border px-2 py-1 text-[11px]",
+        isUpdate
+          ? "border-emerald-400/25 bg-emerald-500/10 text-emerald-100"
+          : isUnverified
+            ? "border-amber-400/25 bg-amber-500/10 text-amber-100"
+            : isBlocked
+              ? "border-orange-400/25 bg-orange-500/10 text-orange-100"
+              : "border-white/10 bg-white/5 text-white/60"
+      )}
+      title={[[role.reason, source].filter(Boolean).join(" / "), ...breakdown]
+        .filter(Boolean)
+        .join("\n")}
+    >
+      <span className="shrink-0" aria-hidden="true">
+        <PlayerRoleIcon role={getRoleIconName(role.role)} size={14} color="currentColor" />
+      </span>
+      <span className="sr-only">{roleLabel}</span>
+
+      {isMissing ? (
+        <span className="opacity-60">missing</span>
+      ) : (
+        <>
+          {isUpdate && role.current_rank_value != null && (
+            <>
+              {currentDivision != null && (
+                <PlayerDivisionIcon division={currentDivision} width={16} height={16} />
+              )}
+              <span className="tabular-nums opacity-50">{role.current_rank_value}</span>
+              <span className="opacity-40">→</span>
+            </>
+          )}
+          {primaryDivision != null && (
+            <PlayerDivisionIcon division={primaryDivision} width={16} height={16} />
+          )}
+          <span className="tabular-nums">{primaryRank ?? "-"}</span>
+          {isUnverified && <span className="opacity-60">не подтверждён</span>}
+        </>
+      )}
+    </div>
+  );
+}
+
+function PlayerLabel({ player }: { player: RegistrationRankAutofillPlayer }) {
+  return player.battle_tag ?? player.display_name ?? `#${player.registration_id}`;
+}
+
+function hasUnverifiedRole(player: RegistrationRankAutofillPlayer): boolean {
+  return player.roles.some((role) => role.action === "unverified");
+}
+
+interface RankAutofillPreviewTablesProps {
+  preview: RegistrationRankAutofillResponse | undefined;
+  loading: boolean;
+  selectedIds: Set<number>;
+  onToggle: (registrationId: number, checked: boolean) => void;
+  onToggleAll: (checked: boolean) => void;
+}
+
+export function RankAutofillPreviewTables({
+  preview,
+  loading,
+  selectedIds,
+  onToggle,
+  onToggleAll
+}: RankAutofillPreviewTablesProps) {
+  if (!preview && !loading) {
+    return (
+      <div className="flex h-32 items-center justify-center text-sm text-white/30">
+        Превью не загружено.
+      </div>
+    );
+  }
+  if (!preview) {
+    return null;
+  }
+
+  const updatablePlayers = preview.players.filter(
+    (player) => player.status === "will_update" || player.status === "applied"
+  );
+  const skippedPlayers = preview.players.filter((player) => player.status === "skipped");
+  const unchangedPlayers = preview.players.filter((player) => player.status === "unchanged");
+
+  const selectableIds = updatablePlayers.map((player) => player.registration_id);
+  const allChecked =
+    selectableIds.length > 0 && selectableIds.every((id) => selectedIds.has(id));
+
+  return (
+    <div className="divide-y divide-white/[0.06]">
+      {/* Will be assigned — with per-player selection */}
+      <div className="px-1 py-3">
+        <div className="mb-2 flex items-center gap-2">
+          <Checkbox
+            checked={allChecked}
+            onCheckedChange={(checked) => onToggleAll(checked === true)}
+            disabled={selectableIds.length === 0 || loading}
+            aria-label="Выбрать всех"
+          />
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-white/40">
+            К назначению
+          </span>
+          <span className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-300">
+            {selectedIds.size}/{updatablePlayers.length}
+          </span>
+        </div>
+        {updatablePlayers.length === 0 ? (
+          <p className="text-xs text-white/30">Нет рангов к обновлению.</p>
+        ) : (
+          <div className="overflow-hidden rounded-xl border border-white/10">
+            {updatablePlayers.map((player) => (
+              <label
+                key={player.registration_id}
+                className="flex min-w-0 cursor-pointer items-center gap-3 border-b border-white/[0.06] px-3 py-2 last:border-b-0 hover:bg-white/[0.02]"
+              >
+                <Checkbox
+                  checked={selectedIds.has(player.registration_id)}
+                  onCheckedChange={(checked) => onToggle(player.registration_id, checked === true)}
+                  disabled={loading}
+                  aria-label={`Выбрать ${PlayerLabel({ player })}`}
+                />
+                <div className="min-w-0 w-48 shrink-0">
+                  <div className="truncate text-sm font-medium text-white/85">
+                    <PlayerLabel player={player} />
+                  </div>
+                  <div className="flex items-center gap-1.5 text-[11px] text-white/30">
+                    <span>#{player.registration_id}</span>
+                    {player.partial && (
+                      <span className="rounded border border-amber-400/20 bg-amber-500/10 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-amber-200">
+                        частично
+                      </span>
+                    )}
+                    {player.will_add_to_balancer && (
+                      <span className="rounded border border-cyan-400/20 bg-cyan-500/10 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-cyan-200">
+                        → Balancer
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex min-w-0 flex-wrap gap-1.5">
+                  {player.roles
+                    .filter((role) => role.action === "set" || role.action === "overwrite")
+                    .map((role) => (
+                      <RankAutofillRolePill key={role.role} role={role} />
+                    ))}
+                </div>
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Skipped + Already set */}
+      <div className="grid gap-px lg:grid-cols-2">
+        <div className="px-1 py-3 lg:pr-4">
+          <div className="mb-2 flex items-center gap-2">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-white/40">
+              Пропущены
+            </span>
+            {skippedPlayers.length > 0 && (
+              <span className="rounded-full bg-orange-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-orange-300">
+                {skippedPlayers.length}
+              </span>
+            )}
+          </div>
+          {skippedPlayers.length === 0 ? (
+            <p className="text-xs text-white/30">Никто не пропущен.</p>
+          ) : (
+            <div className="max-h-72 overflow-y-auto rounded-xl border border-white/10">
+              {skippedPlayers.map((player) => (
+                <div
+                  key={player.registration_id}
+                  className="border-b border-white/[0.06] px-3 py-2 last:border-b-0"
+                >
+                  <div className="truncate text-xs font-medium text-white/75">
+                    <PlayerLabel player={player} />
+                  </div>
+                  <div className="mt-0.5 text-[11px] leading-4 text-orange-200/70">
+                    {player.reason ?? "Пропущен"}
+                  </div>
+                  <div className="mt-1.5 flex flex-wrap gap-1">
+                    {player.roles.map((role) => (
+                      <RankAutofillRolePill key={role.role} role={role} />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="px-1 py-3 lg:border-l lg:border-white/[0.06] lg:pl-4">
+          <div className="mb-2 flex items-center gap-2">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-white/40">
+              Уже заданы
+            </span>
+            {unchangedPlayers.length > 0 && (
+              <span className="rounded-full bg-white/10 px-1.5 py-0.5 text-[10px] font-semibold text-white/40">
+                {unchangedPlayers.length}
+              </span>
+            )}
+          </div>
+          {unchangedPlayers.length === 0 ? (
+            <p className="text-xs text-white/30">Нет неизменённых регистраций.</p>
+          ) : (
+            <div className="max-h-72 overflow-y-auto rounded-xl border border-white/10">
+              {unchangedPlayers.map((player) => (
+                <div
+                  key={player.registration_id}
+                  className="border-b border-white/[0.06] px-3 py-2 last:border-b-0"
+                >
+                  <div className="flex items-center gap-1.5">
+                    <span className="truncate text-xs font-medium text-white/75">
+                      <PlayerLabel player={player} />
+                    </span>
+                    {hasUnverifiedRole(player) && (
+                      <span className="rounded border border-amber-400/20 bg-amber-500/10 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-amber-200">
+                        не подтверждён
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-0.5 text-[11px] leading-4 text-white/35">
+                    {player.reason ?? "Изменения не нужны."}
+                  </div>
+                  {hasUnverifiedRole(player) && (
+                    <div className="mt-1.5 flex flex-wrap gap-1">
+                      {player.roles
+                        .filter((role) => role.action === "unverified")
+                        .map((role) => (
+                          <RankAutofillRolePill key={role.role} role={role} />
+                        ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/balancer/registrations/rank-autofill/_components/RankAutofillStageList.tsx
+++ b/frontend/src/app/balancer/registrations/rank-autofill/_components/RankAutofillStageList.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "lucide-react";
+
+import {
+  STAGE_META,
+  parseLookbackInput,
+  stageWindowValue
+} from "@/app/balancer/components/rank-autofill-stages";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import type {
+  RankAutofillSourceKey,
+  RegistrationRankAutofillStage
+} from "@/types/balancer-admin.types";
+
+interface RankAutofillStageListProps {
+  stages: RegistrationRankAutofillStage[];
+  disabled?: boolean;
+  onReorder: (activeSource: RankAutofillSourceKey, overSource: RankAutofillSourceKey) => void;
+  onToggle: (source: RankAutofillSourceKey, enabled: boolean) => void;
+  onLookbackChange: (source: RankAutofillSourceKey, value: number | null) => void;
+}
+
+interface SortableStageRowProps {
+  stage: RegistrationRankAutofillStage;
+  index: number;
+  disabled: boolean;
+  onToggle: (source: RankAutofillSourceKey, enabled: boolean) => void;
+  onLookbackChange: (source: RankAutofillSourceKey, value: number | null) => void;
+}
+
+function SortableStageRow({
+  stage,
+  index,
+  disabled,
+  onToggle,
+  onLookbackChange
+}: SortableStageRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: stage.source
+  });
+  const meta = STAGE_META[stage.source];
+  const windowValue = stageWindowValue(stage);
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "flex items-center gap-3 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2.5",
+        isDragging && "z-10 opacity-80 shadow-lg shadow-black/40",
+        !stage.enabled && "opacity-55"
+      )}
+    >
+      <button
+        type="button"
+        className="cursor-grab touch-none text-white/30 hover:text-white/60 disabled:cursor-not-allowed"
+        aria-label="Перетащить этап"
+        disabled={disabled}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+
+      <span className="w-4 shrink-0 text-center text-xs font-semibold tabular-nums text-white/35">
+        {index + 1}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-white/85">{meta.label}</div>
+        <div className="truncate text-[11px] text-white/40">{meta.description}</div>
+      </div>
+
+      <label className="flex shrink-0 items-center gap-1.5">
+        <Input
+          type="number"
+          min={1}
+          inputMode="numeric"
+          value={windowValue ?? ""}
+          placeholder={meta.windowPlaceholder}
+          disabled={disabled}
+          onChange={(event) => onLookbackChange(stage.source, parseLookbackInput(event.target.value))}
+          className="h-8 w-16 text-right text-xs"
+          aria-label={`Окно для ${meta.label}`}
+        />
+        <span className="w-9 text-[11px] text-white/40">{meta.windowSuffix}</span>
+      </label>
+
+      <Switch
+        checked={stage.enabled}
+        disabled={disabled}
+        onCheckedChange={(checked) => onToggle(stage.source, checked === true)}
+        aria-label={`Включить ${meta.label}`}
+      />
+    </div>
+  );
+}
+
+export function RankAutofillStageList({
+  stages,
+  disabled = false,
+  onReorder,
+  onToggle,
+  onLookbackChange
+}: RankAutofillStageListProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) {
+      return;
+    }
+    onReorder(active.id as RankAutofillSourceKey, over.id as RankAutofillSourceKey);
+  };
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={stages.map((stage) => stage.source)} strategy={verticalListSortingStrategy}>
+        <div className="flex flex-col gap-2">
+          {stages.map((stage, index) => (
+            <SortableStageRow
+              key={stage.source}
+              stage={stage}
+              index={index}
+              disabled={disabled}
+              onToggle={onToggle}
+              onLookbackChange={onLookbackChange}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/frontend/src/app/balancer/registrations/rank-autofill/page.tsx
+++ b/frontend/src/app/balancer/registrations/rank-autofill/page.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, Check, Loader2 } from "lucide-react";
+
+import {
+  defaultRankAutofillStages,
+  moveStageBySource,
+  setStageEnabled,
+  setStageLookback
+} from "@/app/balancer/components/rank-autofill-stages";
+import { useBalancerTournamentId } from "@/app/balancer/components/useBalancerTournamentId";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { notify } from "@/lib/notify";
+import { cn } from "@/lib/utils";
+import balancerAdminService from "@/services/balancer-admin.service";
+import type {
+  RegistrationRankAutofillRequest,
+  RegistrationRankAutofillResponse
+} from "@/types/balancer-admin.types";
+
+import { RankAutofillPreviewTables } from "./_components/RankAutofillPreviewTables";
+import { RankAutofillStageList } from "./_components/RankAutofillStageList";
+
+function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(handle);
+  }, [value, delay]);
+  return debounced;
+}
+
+export default function RankAutofillPage() {
+  const tournamentId = useBalancerTournamentId();
+  const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
+
+  const [stages, setStages] = useState(() => defaultRankAutofillStages());
+  const [overwriteExisting, setOverwriteExisting] = useState(false);
+  const [addToBalancer, setAddToBalancer] = useState(false);
+  const [allowPartial, setAllowPartial] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+  const previewRequest = useMemo<RegistrationRankAutofillRequest>(
+    () => ({
+      overwrite_existing: overwriteExisting,
+      add_to_balancer: addToBalancer,
+      allow_partial: allowPartial,
+      stages
+    }),
+    [overwriteExisting, addToBalancer, allowPartial, stages]
+  );
+  // Debounce so dragging / typing the lookback inputs doesn't fire a preview per keystroke.
+  const debouncedRequest = useDebouncedValue(previewRequest, 300);
+
+  const previewQuery = useQuery({
+    queryKey: ["balancer-admin", "rank-autofill-preview", tournamentId, debouncedRequest],
+    queryFn: () =>
+      balancerAdminService.previewRegistrationRankAutofill(tournamentId as number, debouncedRequest),
+    enabled: tournamentId !== null,
+    placeholderData: keepPreviousData
+  });
+
+  // Pre-select the actionable players whenever a fresh preview arrives. Done as a render-time
+  // sync (guarded by a stored reference) rather than an effect, per the React "adjusting state
+  // when data changes" pattern — avoids cascading renders.
+  const [syncedPreview, setSyncedPreview] = useState<RegistrationRankAutofillResponse>();
+  if (previewQuery.data && previewQuery.data !== syncedPreview) {
+    setSyncedPreview(previewQuery.data);
+    setSelectedIds(
+      new Set(
+        previewQuery.data.players
+          .filter((player) => player.status === "will_update")
+          .map((player) => player.registration_id)
+      )
+    );
+  }
+
+  const applyMutation = useMutation({
+    mutationFn: () => {
+      if (!tournamentId) {
+        throw new Error("Сначала выберите турнир");
+      }
+      return balancerAdminService.applyRegistrationRankAutofill(tournamentId, {
+        ...previewRequest,
+        registration_ids: Array.from(selectedIds)
+      });
+    },
+    onSuccess: async (result) => {
+      await queryClient.invalidateQueries({
+        queryKey: ["balancer-admin", "registrations", tournamentId]
+      });
+      await previewQuery.refetch();
+      notify.success("Ранги проставлены", {
+        description:
+          `${result.applied_registrations} игрок(ов), ${result.role_updates} ранг(ов) обновлено. ` +
+          `Пропущено: ${result.skipped_registrations}.` +
+          (result.balancer_additions > 0 ? ` ${result.balancer_additions} → balancer.` : "")
+      });
+    },
+    onError: (error: unknown) => notify.apiError(error, { title: "Не удалось проставить ранги" })
+  });
+
+  const handleToggleStage = (source: Parameters<typeof setStageEnabled>[1], enabled: boolean) =>
+    setStages((current) => setStageEnabled(current, source, enabled));
+  const handleReorderStage = (
+    activeSource: Parameters<typeof moveStageBySource>[1],
+    overSource: Parameters<typeof moveStageBySource>[2]
+  ) => setStages((current) => moveStageBySource(current, activeSource, overSource));
+  const handleLookbackChange = (source: Parameters<typeof setStageLookback>[1], value: number | null) =>
+    setStages((current) => setStageLookback(current, source, value));
+
+  const handleTogglePlayer = (registrationId: number, checked: boolean) =>
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (checked) {
+        next.add(registrationId);
+      } else {
+        next.delete(registrationId);
+      }
+      return next;
+    });
+
+  const handleToggleAll = (checked: boolean) => {
+    const updatable = (previewQuery.data?.players ?? [])
+      .filter((player) => player.status === "will_update" || player.status === "applied")
+      .map((player) => player.registration_id);
+    setSelectedIds(checked ? new Set(updatable) : new Set());
+  };
+
+  if (!tournamentId) {
+    return (
+      <Alert>
+        <AlertTitle>Выберите турнир</AlertTitle>
+        <AlertDescription>
+          Выберите турнир в сайдбаре, прежде чем настраивать autofill рангов.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  const registrationsHref = searchParams.toString()
+    ? `/balancer/registrations?${searchParams.toString()}`
+    : "/balancer/registrations";
+
+  const preview = previewQuery.data;
+  const stats = preview
+    ? [
+        { label: "Игроки", value: preview.total_registrations, color: "" },
+        { label: "Обновить", value: preview.updatable_registrations, color: "text-emerald-300" },
+        { label: "Ранги", value: preview.role_updates, color: "text-emerald-300" },
+        { label: "→ Balancer", value: preview.balancer_additions, color: "text-cyan-300" },
+        {
+          label: "Не подтв.",
+          value: preview.unverified_registrations,
+          color: preview.unverified_registrations > 0 ? "text-amber-300" : ""
+        },
+        {
+          label: "Пропуск",
+          value: preview.skipped_registrations,
+          color: preview.skipped_registrations > 0 ? "text-orange-300" : ""
+        }
+      ]
+    : [];
+
+  const applyDisabled = applyMutation.isPending || previewQuery.isFetching || selectedIds.size === 0;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Autofill рангов</h1>
+          <p className="text-sm text-muted-foreground">
+            Настройте цепочку источников и точечно выберите игроков для обновления.
+          </p>
+        </div>
+        <Button variant="outline" asChild>
+          <Link href={registrationsHref}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            К регистрациям
+          </Link>
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Цепочка источников</CardTitle>
+          <CardDescription>
+            Перетащите для порядка приоритета, отключите ненужные источники и при необходимости
+            ограничьте давность (турниры для истории/аналитики, дни для OW).
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <RankAutofillStageList
+            stages={stages}
+            disabled={applyMutation.isPending}
+            onReorder={handleReorderStage}
+            onToggle={handleToggleStage}
+            onLookbackChange={handleLookbackChange}
+          />
+
+          <div className="flex flex-wrap items-center gap-4 border-t border-white/10 pt-3">
+            <label className="flex cursor-pointer items-center gap-2">
+              <Checkbox
+                checked={overwriteExisting}
+                onCheckedChange={(checked) => setOverwriteExisting(checked === true)}
+                disabled={applyMutation.isPending}
+                aria-label="Перезаписывать существующие ранги"
+              />
+              <span className="text-xs text-white/65 select-none">Перезаписывать существующие</span>
+            </label>
+            <label className="flex cursor-pointer items-center gap-2">
+              <Checkbox
+                checked={addToBalancer}
+                onCheckedChange={(checked) => setAddToBalancer(checked === true)}
+                disabled={applyMutation.isPending}
+                aria-label="Перемещать подходящих в balancer"
+              />
+              <span className="text-xs text-white/65 select-none">Перемещать в balancer</span>
+            </label>
+            <label className="flex cursor-pointer items-center gap-2">
+              <Checkbox
+                checked={allowPartial}
+                onCheckedChange={(checked) => setAllowPartial(checked === true)}
+                disabled={applyMutation.isPending}
+                aria-label="Частичное применение"
+              />
+              <span className="text-xs text-white/65 select-none">
+                Частично (заполнять найденные роли, даже если не все найдены)
+              </span>
+            </label>
+            {previewQuery.isFetching && (
+              <div className="ml-auto flex items-center gap-1.5 text-xs text-white/40">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Обновление превью…
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="flex min-h-0 flex-1 flex-col">
+        <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-3">
+          <div>
+            <CardTitle className="text-base">Превью</CardTitle>
+            <CardDescription>Приоритетный fallback по ролям. Только главный BattleTag.</CardDescription>
+          </div>
+          {preview && (
+            <div className="flex shrink-0 items-center divide-x divide-white/10 rounded-lg border border-white/10 bg-white/[0.03]">
+              {stats.map(({ label, value, color }) => (
+                <div key={label} className="px-3 py-2 text-center">
+                  <div className="text-[10px] font-semibold uppercase tracking-wider text-white/35">
+                    {label}
+                  </div>
+                  <div className={cn("text-base font-semibold tabular-nums", color || "text-white/80")}>
+                    {value}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardHeader>
+        <CardContent className="min-h-0 flex-1 overflow-y-auto">
+          {previewQuery.isError ? (
+            <Alert variant="destructive">
+              <AlertTitle>Не удалось загрузить превью</AlertTitle>
+              <AlertDescription>
+                {previewQuery.error instanceof Error ? previewQuery.error.message : "Ошибка запроса"}
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <RankAutofillPreviewTables
+              preview={previewQuery.data}
+              loading={previewQuery.isFetching}
+              selectedIds={selectedIds}
+              onToggle={handleTogglePlayer}
+              onToggleAll={handleToggleAll}
+            />
+          )}
+        </CardContent>
+        <div className="flex shrink-0 items-center justify-between gap-3 border-t border-white/10 px-6 py-3">
+          <span className="text-xs text-white/45">Выбрано игроков: {selectedIds.size}</span>
+          <Button onClick={() => applyMutation.mutate()} disabled={applyDisabled}>
+            {applyMutation.isPending ? (
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+            ) : (
+              <Check className="mr-1.5 h-4 w-4" />
+            )}
+            Применить к {selectedIds.size}
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/balancer/balancer-navigation.ts
+++ b/frontend/src/components/balancer/balancer-navigation.ts
@@ -1,4 +1,12 @@
-import { ArrowLeftRight, ClipboardList, FileSpreadsheet, Settings2, type LucideIcon, UserPlus } from "lucide-react";
+import {
+  ArrowLeftRight,
+  ClipboardList,
+  FileSpreadsheet,
+  Settings2,
+  Sparkles,
+  type LucideIcon,
+  UserPlus
+} from "lucide-react";
 
 import type { AppRole } from "@/hooks/usePermissions";
 
@@ -31,6 +39,12 @@ export const balancerNavigationItems: BalancerNavItem[] = [
     description: "Configure form fields and admission requirements.",
   },
   {
+    title: "Rank autofill",
+    href: "/balancer/registrations/rank-autofill",
+    icon: Sparkles,
+    description: "Autofill ranks from a configurable source chain and pick players.",
+  },
+  {
     title: "Google Sheets",
     href: "/balancer/registrations/feed",
     icon: FileSpreadsheet,
@@ -57,12 +71,17 @@ export function isBalancerNavItemActive(pathname: string, href: string) {
     return pathname === href || pathname.startsWith(`${href}/`);
   }
 
+  if (href === "/balancer/registrations/rank-autofill") {
+    return pathname === href || pathname.startsWith(`${href}/`);
+  }
+
   if (href === "/balancer/registrations") {
     return (
       pathname === href ||
       (pathname.startsWith(`${href}/`) &&
         !pathname.startsWith("/balancer/registrations/feed") &&
-        !pathname.startsWith("/balancer/registrations/form"))
+        !pathname.startsWith("/balancer/registrations/form") &&
+        !pathname.startsWith("/balancer/registrations/rank-autofill"))
     );
   }
 

--- a/frontend/src/types/balancer-admin.types.ts
+++ b/frontend/src/types/balancer-admin.types.ts
@@ -173,6 +173,7 @@ export type RegistrationRankAutofillRoleAction =
   | "set"
   | "overwrite"
   | "keep_existing"
+  | "unverified"
   | "missing_rank"
   | "blocked";
 
@@ -181,18 +182,37 @@ export type RegistrationRankAutofillUsedSource =
   | "ow"
   | "analytics";
 
+/** Individual source of a rank-autofill stage chain. */
+export type RankAutofillSourceKey = "ow" | "division_history" | "analytics";
+
 /**
  * Priority chains for rank autofill:
  *  - ow_first: OW (weekly composite) -> balancer (division history) -> analytics (past tournaments)
  *  - balancer_first: balancer -> analytics -> OW
+ * Legacy presets; superseded by an explicit `stages` chain when one is supplied.
  */
 export type RegistrationRankAutofillMode = "ow_first" | "balancer_first";
+
+/** One source in the autofill priority chain (order = list position). */
+export interface RegistrationRankAutofillStage {
+  source: RankAutofillSourceKey;
+  enabled: boolean;
+  /** Recency window for division_history / analytics, in tournaments (null = no limit). */
+  lookback_tournaments?: number | null;
+  /** Recency window for the OW source, in days (null = default 7-day window). */
+  lookback_days?: number | null;
+}
 
 export interface RegistrationRankAutofillRequest {
   registration_ids?: number[] | null;
   overwrite_existing?: boolean;
   add_to_balancer?: boolean;
+  /** Apply found role ranks even when other active roles have no parsed rank. */
+  allow_partial?: boolean;
+  /** Legacy preset; only used when `stages` is not supplied. */
   mode?: RegistrationRankAutofillMode;
+  /** Explicit ordered priority chain; supersedes `mode` when non-empty. */
+  stages?: RegistrationRankAutofillStage[];
 }
 
 export interface RegistrationRankAutofillRole {
@@ -222,6 +242,8 @@ export interface RegistrationRankAutofillPlayer {
   reason: string | null;
   will_add_to_balancer: boolean;
   balancer_reason: string | null;
+  /** Some active roles were filled but others had no parsed rank (allow_partial). */
+  partial?: boolean;
   roles: RegistrationRankAutofillRole[];
 }
 
@@ -231,6 +253,8 @@ export interface RegistrationRankAutofillResponse {
   applied_registrations: number;
   skipped_registrations: number;
   unchanged_registrations: number;
+  /** Registrations with >=1 active role whose current rank no enabled source could corroborate. */
+  unverified_registrations: number;
   role_updates: number;
   overwrite_existing: boolean;
   add_to_balancer: boolean;


### PR DESCRIPTION
…artial apply

Rework the registration rank-autofill admin tool:
- Replace fixed ow_first/balancer_first presets with a configurable stage chain (stages override mode): per-source enable/disable, drag-and-drop order, and recency windows (N tournaments for analytics/division history, days for OW). Disabled sources are no longer queried.
- Add allow_partial: apply found role ranks even when other active roles have no parsed rank, without ever clearing an existing rank.
- Add an `unverified` role action for a current rank no enabled source corroborated, surfaced via unverified_registrations.
- Move the tool off the overloaded modal to a dedicated sub-page /balancer/registrations/rank-autofill with a @dnd-kit stage editor and per-player selection checkboxes.

Backend: full tournament-service suite green (267). Frontend: tsc/eslint clean, vitest stage helpers 9/9.