### PR TITLE
fix(balancer): make rank-autofill player grid 3 equal columns

### DIFF
--- a/frontend/src/app/balancer/registrations/rank-autofill/_components/RankAutofillPreviewTables.tsx
+++ b/frontend/src/app/balancer/registrations/rank-autofill/_components/RankAutofillPreviewTables.tsx
@@ -220,7 +220,7 @@ export function RankAutofillPreviewTables({
         {updatablePlayers.length === 0 ? (
           <p className="text-xs text-white/30">{t("rankAutofill.noRanksToUpdate")}</p>
         ) : (
-          <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
             {updatablePlayers.map((player) => (
               <label
                 key={player.registration_id}


### PR DESCRIPTION
Drop the 2-column intermediate breakpoint: the previous sm:grid-cols-2 xl:grid-cols-3 only reached 3 columns at 1280px viewport, so the admin content area (narrowed by the sidebar) stayed at 2. Use grid-cols-3 from the sm breakpoint up — three equal-width tracks (repeat(3, minmax(0,1fr))).