### PR TITLE
fix(balancer): treat rank delta as advisory, not a Need Fix rule

### DIFF
--- a/frontend/src/app/balancer/components/BalancingPoolSidebar.tsx
+++ b/frontend/src/app/balancer/components/BalancingPoolSidebar.tsx
@@ -28,7 +28,7 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type { AdminRegistration, BalancerApplication, StatusMeta, WorkspaceBalancerConfig } from "@/types/balancer-admin.types";
 import type { PlayerValidationState, PoolView, PoolSortValue } from "./balancer-page-helpers";
-import { PANEL_CLASS, sortPlayerStates } from "./balancer-page-helpers";
+import { PANEL_CLASS, hasBlockingIssues, sortPlayerStates } from "./balancer-page-helpers";
 import { buildPlayerSearchIndex } from "./workspace-helpers";
 import { PoolSearchCombobox } from "./PoolSearchCombobox";
 import { PoolPlayerCompactList } from "./PoolPlayerCompactList";
@@ -174,11 +174,11 @@ export const BalancingPoolSidebar = forwardRef<BalancingPoolSidebarHandle, Balan
       [allPlayerValidationStates],
     );
     const readyPlayers = useMemo(
-      () => poolPlayers.filter((s) => s.issues.length === 0),
+      () => poolPlayers.filter((s) => !hasBlockingIssues(s.issues)),
       [poolPlayers],
     );
     const invalidPlayers = useMemo(
-      () => poolPlayers.filter((s) => s.issues.length > 0),
+      () => poolPlayers.filter((s) => hasBlockingIssues(s.issues)),
       [poolPlayers],
     );
     const rankDeltaPlayers = useMemo(
@@ -203,8 +203,8 @@ export const BalancingPoolSidebar = forwardRef<BalancingPoolSidebarHandle, Balan
           if (!state.player.is_in_pool) return false;
           if (hideFromPool && state.issues.some((i) => i.code === "rank_delta_warning")) return false;
         }
-        if (poolView === "ready" && state.issues.length > 0) return false;
-        if (poolView === "needs_fix" && state.issues.length === 0) return false;
+        if (poolView === "ready" && hasBlockingIssues(state.issues)) return false;
+        if (poolView === "needs_fix" && !hasBlockingIssues(state.issues)) return false;
         if (!normalizedSearchQuery) return true;
         return buildPlayerSearchIndex(
           state.player,

--- a/frontend/src/app/balancer/components/PoolTriageBoard.tsx
+++ b/frontend/src/app/balancer/components/PoolTriageBoard.tsx
@@ -40,6 +40,7 @@ import {
   POOL_LANES,
   POOL_LANE_LABELS,
   derivePoolLane,
+  hasBlockingIssues,
   getPoolDropPatch,
   getRegistrationBattleTags,
   type PlayerValidationState,
@@ -239,7 +240,7 @@ function TriagePlayerCard({
   const battleTags = getRegistrationBattleTags(registration, state.player.battle_tag);
   const primaryBattleTag = battleTags[0] ?? state.player.battle_tag;
   const smurfTags = battleTags.slice(1);
-  const isReady = state.player.is_in_pool && state.issues.length === 0;
+  const isReady = state.player.is_in_pool && !hasBlockingIssues(state.issues);
 
   return (
     <ContextMenu>

--- a/frontend/src/app/balancer/components/balancer-page-helpers.ts
+++ b/frontend/src/app/balancer/components/balancer-page-helpers.ts
@@ -33,12 +33,31 @@ export const POOL_LANE_LABELS: Record<PoolLane, string> = {
   ready: "Ready"
 };
 
+/**
+ * Issue codes that are purely informational — extra balancing context, not a blocking rule.
+ * They still surface as chips and in the Rank Δ view, but must NOT push a player into the
+ * Need Fix lane. The rank-delta warning is advisory: a large gap between the balancer rank and
+ * the OW rank is something to be aware of when balancing, not a problem that has to be fixed.
+ */
+const NON_BLOCKING_ISSUE_CODES: ReadonlySet<PlayerValidationIssue["code"]> = new Set([
+  "rank_delta_warning"
+]);
+
+export function isBlockingIssue(issue: PlayerValidationIssue): boolean {
+  return !NON_BLOCKING_ISSUE_CODES.has(issue.code);
+}
+
+/** Whether a player has any issue that should move them into the Need Fix lane. */
+export function hasBlockingIssues(issues: PlayerValidationIssue[]): boolean {
+  return issues.some(isBlockingIssue);
+}
+
 export function derivePoolLane(state: PlayerValidationState): PoolLane {
   if (!state.player.is_in_pool) {
     return "excluded";
   }
 
-  return state.issues.length > 0 ? "needs_fix" : "ready";
+  return hasBlockingIssues(state.issues) ? "needs_fix" : "ready";
 }
 
 export function getPoolDropPatch(targetLane: PoolLane): PoolDropPatch {

--- a/frontend/src/app/balancer/components/workspace-helpers.test.ts
+++ b/frontend/src/app/balancer/components/workspace-helpers.test.ts
@@ -299,6 +299,34 @@ describe("pool lane helpers", () => {
 
     expect(derivePoolLane({ player, issues: getPlayerValidationIssues(player, null) })).toBe("ready");
   });
+
+  it("keeps a player whose only issue is a rank-delta warning in Ready", () => {
+    const player = createPlayer({
+      role_entries_json: [
+        { role: "support", subtype: null, priority: 1, division_number: 12, rank_value: 900, is_active: true, ow_rank_value: 2000 },
+      ],
+    });
+    const issues = getPlayerValidationIssues(player, null, { rank_delta_threshold: 100 });
+
+    // The advisory rank-delta chip is still emitted as informational context...
+    expect(issues.some((issue) => issue.code === "rank_delta_warning")).toBe(true);
+    // ...but a rank delta on its own must not push the player into Need Fix.
+    expect(derivePoolLane({ player, issues })).toBe("ready");
+  });
+
+  it("still routes a rank-delta player into Need Fix when a blocking issue is also present", () => {
+    const player = createPlayer({
+      role_entries_json: [
+        { role: "support", subtype: null, priority: 1, division_number: 12, rank_value: 900, is_active: true, ow_rank_value: 2000 },
+      ],
+    });
+    const application = createApplication({ primary_role: "tank", additional_roles_json: [] });
+    const issues = getPlayerValidationIssues(player, application, { rank_delta_threshold: 100 });
+
+    expect(issues.some((issue) => issue.code === "rank_delta_warning")).toBe(true);
+    expect(issues.some((issue) => issue.code === "application_role_mismatch")).toBe(true);
+    expect(derivePoolLane({ player, issues })).toBe("needs_fix");
+  });
 });
 
 describe("battle tag clipboard helpers", () => {


### PR DESCRIPTION
The rank-delta warning is extra balancing context (gap between the balancer rank and the OW rank), not a problem that must be fixed. Previously any rank delta over the workspace threshold emitted a validation issue, and the pool lane / Need Fix counters treated every issue as blocking — so those players were pushed into Need Fix.

Introduce isBlockingIssue / hasBlockingIssues helpers and classify rank_delta_warning as non-blocking. derivePoolLane, the Ready badge, and the sidebar Ready / Need Fix counts and view filters now ignore advisory issues. The chip and dedicated Rank Δ view still surface the delta as information.