### PR TITLE
feat(balancer): role-validated DnD with live recompute and realtime d…

### DIFF
--- a/backend/balancer-service/src/schemas/balancer.py
+++ b/backend/balancer-service/src/schemas/balancer.py
@@ -180,6 +180,10 @@ class PlayerData(BaseModel):
     is_captain: bool
     role_preferences: list[str]
     all_ratings: dict[str, int]
+    # Stable per-role discomfort snapshot (computed from original preferences),
+    # so the frontend can re-derive discomfort when a player is moved between
+    # roles without re-running the solver. Defaulted for legacy payloads.
+    all_discomforts: dict[str, int] = Field(default_factory=dict)
     is_flex: bool = False
     sub_role: str | None = None
 

--- a/backend/balancer-service/src/services/balancer/algorithm/result_serializer.py
+++ b/backend/balancer-service/src/services/balancer/algorithm/result_serializer.py
@@ -54,6 +54,7 @@ def teams_to_json(
                     "is_flex": player.is_flex,
                     "role_preferences": player.preferences,
                     "all_ratings": player.ratings,
+                    "all_discomforts": player.discomfort_map,
                     "sub_role": player.subclasses.get(role) or None,
                 }
                 for player in players
@@ -125,6 +126,7 @@ def teams_to_json(
                 "is_flex": player.is_flex,
                 "role_preferences": player.preferences,
                 "all_ratings": player.ratings,
+                "all_discomforts": player.discomfort_map,
             }
             for player in benched_players
         ]

--- a/backend/balancer-service/tests/test_result_serializer.py
+++ b/backend/balancer-service/tests/test_result_serializer.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+REPO_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+BALANCER_SERVICE_ROOT = REPO_BACKEND_ROOT / "balancer-service"
+
+for candidate in (str(REPO_BACKEND_ROOT), str(BALANCER_SERVICE_ROOT)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+os.environ.setdefault("PROJECT_URL", "http://localhost")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("POSTGRES_USER", "postgres")
+os.environ.setdefault("POSTGRES_PASSWORD", "postgres")
+os.environ.setdefault("POSTGRES_DB", "postgres")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("CHALLONGE_USERNAME", "test")
+os.environ.setdefault("CHALLONGE_API_KEY", "test")
+os.environ.setdefault("S3_ACCESS_KEY", "test")
+os.environ.setdefault("S3_SECRET_KEY", "test")
+os.environ.setdefault("S3_ENDPOINT_URL", "http://localhost")
+os.environ.setdefault("S3_BUCKET_NAME", "test")
+
+from src.services.balancer.algorithm.entities import Player, Team  # noqa: E402
+from src.services.balancer.algorithm.result_serializer import teams_to_json  # noqa: E402
+
+MASK = {"Tank": 1, "Damage": 2, "Support": 2}
+
+
+def make_player(uuid: str, ratings: dict[str, int], preferences: list[str]) -> Player:
+    return Player(name=f"P{uuid}", ratings=ratings, preferences=preferences, uuid=uuid, mask=MASK)
+
+
+def test_roster_player_exposes_all_discomforts_snapshot() -> None:
+    player = make_player("1", {"Tank": 3000, "Damage": 2900}, ["Tank", "Damage"])
+    team = Team(1, MASK)
+    team.add_player("Tank", player)
+
+    result = teams_to_json([team], MASK)
+    serialized = result["teams"][0]["roster"]["Tank"][0]
+
+    # Snapshot mirrors Player.discomfort_map: primary role 0, second pref 100,
+    # an unplayable masked role 5000.
+    assert serialized["all_discomforts"] == {"Tank": 0, "Damage": 100, "Support": 5000}
+    assert serialized["all_discomforts"] == player.discomfort_map
+
+
+def test_benched_player_exposes_all_discomforts() -> None:
+    placed = make_player("1", {"Tank": 3000}, ["Tank"])
+    benched = make_player("2", {"Damage": 2800, "Support": 2700}, ["Damage", "Support"])
+    team = Team(1, MASK)
+    team.add_player("Tank", placed)
+
+    result = teams_to_json([team], MASK, benched_players=[benched])
+    assert result["benched_players"][0]["all_discomforts"] == benched.discomfort_map

--- a/backend/realtime-service/src/routes/ws.py
+++ b/backend/realtime-service/src/routes/ws.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
-from time import perf_counter
+from time import monotonic, perf_counter
 from typing import Any, cast
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from loguru import logger
 from shared.models.auth_user import AuthUser
 from shared.models.realtime import WorkspaceEvent
-from shared.schemas.realtime import SubscribeOp, WorkspaceEventEnvelope
-from shared.services.balancer_realtime import BALANCER_PRESENCE
+from shared.schemas.realtime import PublishOp, SubscribeOp, WorkspaceEventEnvelope
+from shared.services.balancer_realtime import BALANCER_DRAG, BALANCER_PRESENCE
 from shared.services.realtime_publisher import event_to_envelope
 
 from src.core import config, db
@@ -32,6 +32,20 @@ from src.services.event_replay import ReplayGapTooLarge, event_replay_service
 from src.services.topic_acl import topic_acl_registry
 
 router = APIRouter()
+
+# Event types clients are allowed to publish over the WebSocket. Everything else
+# (data-edit signals, job lifecycle, presence) is server-originated only, so a
+# client cannot persist events or forge a `*_changed`/job frame.
+PUBLISHABLE_EVENT_TYPES: frozenset[str] = frozenset({BALANCER_DRAG})
+
+# Per-connection ceiling on client-originated ephemeral frames. Drag is throttled
+# client-side (~25-30/s); this is generous headroom and only guards against abuse.
+MAX_PUBLISH_PER_SECOND = 60
+
+# Hard cap on a single client frame before any JSON parsing. Every legitimate op
+# (subscribe/unsubscribe/ping/publish) is well under 1 KB; this guards json.loads
+# against oversized payloads on the (now writable) client->server path.
+MAX_CLIENT_FRAME_CHARS = 8192
 
 
 async def _broadcast_presence(topic: str) -> None:
@@ -67,6 +81,12 @@ async def ws_endpoint(websocket: WebSocket) -> None:
                 await websocket.close(code=1001)
                 return
 
+            if len(raw_frame) > MAX_CLIENT_FRAME_CHARS:
+                await connection_manager.send(
+                    state, error_frame("frame_too_large", "Frame exceeds the maximum allowed size")
+                )
+                continue
+
             try:
                 op = parse_client_op(raw_frame)
             except ProtocolError as exc:
@@ -81,6 +101,10 @@ async def ws_endpoint(websocket: WebSocket) -> None:
                 connection_manager.unsubscribe(state, op.topic)
                 if is_presence_topic(op.topic):
                     await _broadcast_presence(op.topic)
+                continue
+
+            if op.op == "publish":
+                await _handle_publish(state, cast(PublishOp, op))
                 continue
 
             await _handle_subscribe(state, cast(SubscribeOp, op), user)
@@ -98,6 +122,58 @@ async def ws_endpoint(websocket: WebSocket) -> None:
 async def _resolve_websocket_user(websocket: WebSocket) -> AuthUser | None:
     async with db.async_session_maker() as session:
         return await get_websocket_user_optional(websocket, session)
+
+
+async def _handle_publish(state: ConnectionState, op: PublishOp) -> None:
+    """Fan a client-originated ephemeral frame to a topic's other subscribers.
+
+    Security boundary for the only client→server broadcast path:
+    * authenticated users only (anonymous connections cannot originate events);
+    * the topic must already be subscribed — so it passed the topic ACL;
+    * the event type must be on the publish allowlist (no persisted/forged events);
+    * the actor id is stamped from the connection, never trusted from the client;
+    * ``event_id=0`` keeps it ephemeral (never advances the replay cursor);
+    * the sender is excluded from fan-out (it renders its own action locally);
+    * a per-connection rate limit drops abusive bursts (frames are disposable).
+    """
+    if state.user is None:
+        await connection_manager.send(
+            state,
+            error_frame("forbidden", "Authentication required to publish", topic=op.topic),
+        )
+        return
+
+    if op.topic not in state.topics:
+        await connection_manager.send(
+            state,
+            error_frame("not_subscribed", "Subscribe to the topic before publishing", topic=op.topic),
+        )
+        return
+
+    if op.event_type not in PUBLISHABLE_EVENT_TYPES:
+        await connection_manager.send(
+            state,
+            error_frame("forbidden_event", "This event type cannot be published by clients", topic=op.topic),
+        )
+        return
+
+    now = monotonic()
+    if now - state.publish_window_start >= 1.0:
+        state.publish_window_start = now
+        state.publish_window_count = 0
+    state.publish_window_count += 1
+    if state.publish_window_count > MAX_PUBLISH_PER_SECOND:
+        return
+
+    envelope = WorkspaceEventEnvelope(
+        event_id=0,
+        event_type=op.event_type,
+        schema_version=1,
+        occurred_at=datetime.now(UTC),
+        actor_user_id=state.user.id,
+        data=op.data,
+    )
+    await connection_manager.route(op.topic, event_frame(op.topic, envelope), exclude=state)
 
 
 async def _handle_subscribe(state: ConnectionState, op: SubscribeOp, user: AuthUser | None) -> None:

--- a/backend/realtime-service/src/services/connection_manager.py
+++ b/backend/realtime-service/src/services/connection_manager.py
@@ -19,6 +19,9 @@ class ConnectionState:
     user: AuthUser | None
     topics: set[str] = field(default_factory=set)
     send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    # Sliding 1-second window for client-originated ephemeral publishes.
+    publish_window_start: float = 0.0
+    publish_window_count: int = 0
 
 
 class ConnectionManager:
@@ -50,8 +53,18 @@ class ConnectionManager:
             return False
         return True
 
-    async def route(self, topic: str, frame: dict[str, Any]) -> None:
-        states = [state for state in list(self._states) if topic in state.topics]
+    async def route(
+        self,
+        topic: str,
+        frame: dict[str, Any],
+        *,
+        exclude: ConnectionState | None = None,
+    ) -> None:
+        states = [
+            state
+            for state in list(self._states)
+            if topic in state.topics and state is not exclude
+        ]
         if not states:
             return
 

--- a/backend/realtime-service/tests/test_balancer_publish.py
+++ b/backend/realtime-service/tests/test_balancer_publish.py
@@ -1,0 +1,108 @@
+"""Tests for the client-originated ephemeral publish path (live-drag overlay)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+backend_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(backend_root))
+sys.path.insert(0, str(backend_root / "realtime-service"))
+
+os.environ.setdefault("PROJECT_URL", "http://localhost")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("POSTGRES_USER", "postgres")
+os.environ.setdefault("POSTGRES_PASSWORD", "postgres")
+os.environ.setdefault("POSTGRES_DB", "postgres")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+
+from shared.schemas.realtime import PublishOp  # noqa: E402
+
+from src.routes import ws  # noqa: E402
+from src.services.connection_manager import ConnectionState  # noqa: E402
+
+TOPIC = "tournament:1:balancer"
+
+
+def _state(user_id: int | None, *topics: str) -> ConnectionState:
+    user = SimpleNamespace(id=user_id) if user_id is not None else None
+    return ConnectionState(websocket=MagicMock(), user=user, topics=set(topics))
+
+
+def _drag_op(topic: str = TOPIC, event_type: str = "balancer.drag") -> PublishOp:
+    return PublishOp(op="publish", topic=topic, event_type=event_type, data={"phase": "start"})
+
+
+class HandlePublishTests(IsolatedAsyncioTestCase):
+    async def test_anonymous_connection_is_rejected(self) -> None:
+        state = _state(None, TOPIC)
+        with patch.object(ws, "connection_manager") as mgr:
+            mgr.send = AsyncMock()
+            mgr.route = AsyncMock()
+            await ws._handle_publish(state, _drag_op())
+        mgr.route.assert_not_awaited()
+        self.assertEqual(mgr.send.await_args.args[1]["code"], "forbidden")
+
+    async def test_publish_to_unsubscribed_topic_is_rejected(self) -> None:
+        state = _state(5)  # authenticated but not subscribed to TOPIC
+        with patch.object(ws, "connection_manager") as mgr:
+            mgr.send = AsyncMock()
+            mgr.route = AsyncMock()
+            await ws._handle_publish(state, _drag_op())
+        mgr.route.assert_not_awaited()
+        self.assertEqual(mgr.send.await_args.args[1]["code"], "not_subscribed")
+
+    async def test_non_allowlisted_event_type_is_rejected(self) -> None:
+        state = _state(5, TOPIC)
+        with patch.object(ws, "connection_manager") as mgr:
+            mgr.send = AsyncMock()
+            mgr.route = AsyncMock()
+            await ws._handle_publish(state, _drag_op(event_type="balancer.balance_saved"))
+        mgr.route.assert_not_awaited()
+        self.assertEqual(mgr.send.await_args.args[1]["code"], "forbidden_event")
+
+    async def test_valid_publish_fans_out_with_server_stamped_actor(self) -> None:
+        state = _state(5, TOPIC)
+        with patch.object(ws, "connection_manager") as mgr:
+            mgr.send = AsyncMock()
+            mgr.route = AsyncMock()
+            await ws._handle_publish(state, _drag_op())
+
+        mgr.send.assert_not_awaited()  # no error frame
+        mgr.route.assert_awaited_once()
+        args, kwargs = mgr.route.await_args
+        self.assertEqual(args[0], TOPIC)
+        self.assertIs(kwargs["exclude"], state)  # sender does not echo to itself
+        event = args[1]["event"]
+        self.assertEqual(event["event_id"], 0)  # ephemeral, never persisted
+        self.assertEqual(event["event_type"], "balancer.drag")
+        self.assertEqual(event["actor_user_id"], 5)  # stamped from connection, not client
+
+    async def test_rate_limit_drops_excess_frames(self) -> None:
+        state = _state(5, TOPIC)
+        with patch.object(ws, "connection_manager") as mgr, patch.object(ws, "monotonic", return_value=1000.0):
+            mgr.send = AsyncMock()
+            mgr.route = AsyncMock()
+            for _ in range(ws.MAX_PUBLISH_PER_SECOND + 10):
+                await ws._handle_publish(state, _drag_op())
+
+        self.assertEqual(mgr.route.await_count, ws.MAX_PUBLISH_PER_SECOND)
+
+
+class PublishOpValidationTests(TestCase):
+    def test_data_key_count_is_bounded(self) -> None:
+        # A handful of keys is fine (drag payloads carry ~7 scalar fields).
+        PublishOp(op="publish", topic=TOPIC, event_type="balancer.drag", data={"phase": "start"})
+
+        # An oversized data dict is rejected before fan-out (DoS amplification guard).
+        oversized = {f"k{i}": i for i in range(33)}
+        with pytest.raises(ValidationError):
+            PublishOp(op="publish", topic=TOPIC, event_type="balancer.drag", data=oversized)

--- a/backend/shared/schemas/realtime.py
+++ b/backend/shared/schemas/realtime.py
@@ -10,6 +10,7 @@ __all__ = (
     "EventFrame",
     "PingOp",
     "PongFrame",
+    "PublishOp",
     "SubscribeOp",
     "SubscribedFrame",
     "TopicPattern",
@@ -68,7 +69,26 @@ class PingOp(BaseModel):
     op: Literal["ping"]
 
 
-ClientOp = Annotated[SubscribeOp | UnsubscribeOp | PingOp, Field(discriminator="op")]
+class PublishOp(BaseModel):
+    """Client-originated ephemeral broadcast to a subscribed topic.
+
+    Used for transient collaboration cues (e.g. live drag overlays) that are
+    fanned out to co-subscribers without being persisted. The realtime-service
+    enforces auth, topic subscription, an event-type allowlist, and server-side
+    stamping of the actor — clients cannot persist events or spoof identity.
+    """
+
+    op: Literal["publish"]
+    topic: str = Field(min_length=1, max_length=255)
+    event_type: str = Field(min_length=1, max_length=64)
+    # Bounded key count: legitimate ephemeral payloads (drag overlays) carry a
+    # handful of scalar fields. Caps fan-out amplification from a single client.
+    data: dict[str, Any] = Field(default_factory=dict, max_length=32)
+
+
+ClientOp = Annotated[
+    SubscribeOp | UnsubscribeOp | PingOp | PublishOp, Field(discriminator="op")
+]
 
 
 class SubscribedFrame(BaseModel):

--- a/backend/shared/services/balancer_realtime.py
+++ b/backend/shared/services/balancer_realtime.py
@@ -29,6 +29,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 __all__ = (
     "BALANCER_BALANCE_SAVED",
     "BALANCER_CONFIG_CHANGED",
+    "BALANCER_DRAG",
     "BALANCER_JOB_FAILED",
     "BALANCER_JOB_PROGRESS",
     "BALANCER_JOB_QUEUED",
@@ -56,6 +57,13 @@ BALANCER_JOB_FAILED = "balancer_job.failed"
 # Ephemeral presence (NOT published via publish_balancer_event; emitted by
 # realtime-service directly). Declared here so the literal has one home.
 BALANCER_PRESENCE = "balancer.presence"
+
+# Ephemeral live-drag overlay. Client-originated (published over the WebSocket
+# via the `publish` op) and fanned out to co-subscribers by realtime-service;
+# never persisted and never published through publish_balancer_event. This is
+# the single event type the realtime-service allows clients to publish on the
+# balancer topic — see the publish allowlist in realtime-service ws routes.
+BALANCER_DRAG = "balancer.drag"
 
 
 async def publish_balancer_event(

--- a/frontend/src/app/balancer/components/BalancerEditorPanel.tsx
+++ b/frontend/src/app/balancer/components/BalancerEditorPanel.tsx
@@ -20,6 +20,9 @@ type BalancerEditorPanelProps = {
   invalidPlayerCount: number;
   canRunBalance: boolean;
   isRunPending: boolean;
+  realtimeTopic?: string | null;
+  currentUserId?: number | null;
+  workspaceId?: number | null;
   onChangePayload: (payload: InternalBalancePayload) => void;
   onSelectPlayer: (playerId: number | null) => void;
   onToggleTeam: (teamId: number) => void;
@@ -38,6 +41,9 @@ export function BalancerEditorPanel({
   invalidPlayerCount,
   canRunBalance,
   isRunPending,
+  realtimeTopic = null,
+  currentUserId = null,
+  workspaceId = null,
   onChangePayload,
   onSelectPlayer,
   onToggleTeam,
@@ -58,6 +64,9 @@ export function BalancerEditorPanel({
             onSelectPlayer={onSelectPlayer}
             collapsedTeamIds={collapsedTeamIds}
             onToggleTeam={onToggleTeam}
+            realtimeTopic={realtimeTopic}
+            currentUserId={currentUserId}
+            workspaceId={workspaceId}
           />
         </div>
       ) : (

--- a/frontend/src/app/balancer/components/BalancerMainPageClient.tsx
+++ b/frontend/src/app/balancer/components/BalancerMainPageClient.tsx
@@ -17,8 +17,12 @@ import { VariantSelector } from "@/app/balancer/components/VariantSelector";
 import { useBalancerTournamentId } from "@/app/balancer/components/useBalancerTournamentId";
 import { useBalancerJob } from "@/app/balancer/components/useBalancerJob";
 import { useBalancerMutations } from "@/app/balancer/components/useBalancerMutations";
-import { useBalancerRealtime } from "@/app/balancer/components/useBalancerRealtime";
+import {
+  balancerRealtimeTopic,
+  useBalancerRealtime,
+} from "@/app/balancer/components/useBalancerRealtime";
 import { useDivisionGrid } from "@/hooks/useCurrentWorkspace";
+import { useAuthProfileStore } from "@/stores/auth-profile.store";
 import { mergeStatusOptions } from "@/lib/balancer-statuses";
 import { notify } from "@/lib/notify";
 import balancerAdminService from "@/services/balancer-admin.service";
@@ -115,6 +119,7 @@ export function BalancerMainPageClient() {
   const tournamentId = useBalancerTournamentId();
   const divisionGrid = useDivisionGrid();
   const workspaceId = useWorkspaceStore((state) => state.currentWorkspaceId);
+  const currentUserId = useAuthProfileStore((state) => state.user?.id ?? null);
   const queryClient = useQueryClient();
   const sidebarRef = useRef<BalancingPoolSidebarHandle>(null);
   const balanceEditorRef = useRef<HTMLDivElement | null>(null);
@@ -776,6 +781,9 @@ export function BalancerMainPageClient() {
               invalidPlayerCount={invalidPlayerStates.length}
               canRunBalance={canRunBalance}
               isRunPending={runBalanceMutation.isPending}
+              realtimeTopic={balancerRealtimeTopic(tournamentId)}
+              currentUserId={currentUserId}
+              workspaceId={workspaceId}
               onChangePayload={handleBalancePayloadChange}
               onSelectPlayer={handleOpenPlayerEditor}
               onToggleTeam={handleToggleTeam}

--- a/frontend/src/app/balancer/components/BalancerPresenceStack.tsx
+++ b/frontend/src/app/balancer/components/BalancerPresenceStack.tsx
@@ -10,6 +10,7 @@ import workspaceService from "@/services/workspace.service";
 import { useAuthProfileStore } from "@/stores/auth-profile.store";
 import type { WorkspaceMember } from "@/types/workspace.types";
 import { cn } from "@/lib/utils";
+import { memberDisplayName } from "@/lib/workspace-member";
 
 /** Portal target rendered by {@link BalancerSidebar} in its footer. */
 const PRESENCE_SLOT_ID = "balancer-presence-slot";
@@ -21,14 +22,6 @@ type BalancerPresenceStackProps = {
   userIds: number[];
   workspaceId: number | null;
 };
-
-function memberDisplayName(member: WorkspaceMember | undefined, userId: number): string {
-  if (!member) {
-    return `User #${userId}`;
-  }
-  const fullName = [member.first_name, member.last_name].filter(Boolean).join(" ").trim();
-  return fullName || member.username || member.email || `User #${userId}`;
-}
 
 function initials(name: string): string {
   const parts = name.split(/\s+/).filter(Boolean);

--- a/frontend/src/app/balancer/components/balancer-page-helpers.ts
+++ b/frontend/src/app/balancer/components/balancer-page-helpers.ts
@@ -234,3 +234,76 @@ export function calculateOffRoleCountFromPayload(
     0
   );
 }
+
+/**
+ * Sample standard deviation. Mirrors the backend `_sample_stdev_from_sums`
+ * (Bessel-corrected, like Python's `statistics.stdev`); returns 0 for < 2 values.
+ */
+export function sampleStdDev(values: number[]): number {
+  const n = values.length;
+  if (n < 2) {
+    return 0;
+  }
+  const sum = values.reduce((acc, value) => acc + value, 0);
+  const sumOfSquares = values.reduce((acc, value) => acc + value * value, 0);
+  const variance = (sumOfSquares - (sum * sum) / n) / (n - 1);
+  return variance > 0 ? Math.sqrt(variance) : 0;
+}
+
+/** All per-player assigned ratings of a team, flattened across role buckets. */
+export function collectTeamRatings(team: InternalBalancePayload["teams"][number]): number[] {
+  return BALANCE_ROSTER_KEYS.flatMap((roleKey) =>
+    team.roster[roleKey].map((player) => player.assigned_rating)
+  );
+}
+
+/** Intra-team rating spread (mirrors backend `Team.intra_std`). */
+export function calculateTeamVarianceFromPayload(
+  team: InternalBalancePayload["teams"][number]
+): number {
+  return sampleStdDev(collectTeamRatings(team));
+}
+
+/** Total and max role-discomfort across a team (mirrors `Team.discomfort` / `max_pain`). */
+export function calculateTeamDiscomfortFromPayload(
+  team: InternalBalancePayload["teams"][number]
+): { total: number; max: number } {
+  let total = 0;
+  let max = 0;
+  for (const roleKey of BALANCE_ROSTER_KEYS) {
+    for (const player of team.roster[roleKey]) {
+      const discomfort = player.role_discomfort ?? 0;
+      total += discomfort;
+      if (discomfort > max) {
+        max = discomfort;
+      }
+    }
+  }
+  return { total, max };
+}
+
+/**
+ * Sub-role collisions within a team: for each (role, sub_role) pair occurring
+ * more than once, add C(n, 2). Mirrors `result_serializer.teams_to_json`.
+ */
+export function calculateSubRoleCollisionsFromPayload(
+  team: InternalBalancePayload["teams"][number]
+): number {
+  let collisions = 0;
+  for (const roleKey of BALANCE_ROSTER_KEYS) {
+    const counts = new Map<string, number>();
+    for (const player of team.roster[roleKey]) {
+      const subRole = player.sub_role;
+      if (!subRole) {
+        continue;
+      }
+      counts.set(subRole, (counts.get(subRole) ?? 0) + 1);
+    }
+    for (const occurrences of counts.values()) {
+      if (occurrences > 1) {
+        collisions += (occurrences * (occurrences - 1)) / 2;
+      }
+    }
+  }
+  return collisions;
+}

--- a/frontend/src/components/balancer/BalanceEditor.tsx
+++ b/frontend/src/components/balancer/BalanceEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useMemo, useState } from "react";
+import { forwardRef, useCallback, useMemo, useState } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -8,24 +8,34 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
 } from "@dnd-kit/core";
+import { useQuery } from "@tanstack/react-query";
 import { UserX } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
-import type { DivisionGrid } from "@/types/workspace.types";
+import workspaceService from "@/services/workspace.service";
+import { memberDisplayName } from "@/lib/workspace-member";
+import type { DivisionGrid, WorkspaceMember } from "@/types/workspace.types";
 import type {
   BalancerRosterKey,
   InternalBalancePayload,
   InternalBalancePlayer,
 } from "@/types/balancer-admin.types";
 
+import { BALANCE_ROSTER_KEYS } from "@/app/balancer/components/balancer-page-helpers";
+
 import { BalanceEditorPlayerPreviewRow } from "./BalanceEditorPlayerRows";
 import { BalanceEditorTeamCard } from "./BalanceEditorTeamCard";
 import {
-  getDraggedBalancePlayer,
+  canPlayerPlayRole,
+  findBalancePlayerLocation,
   moveBalancePlayer,
   resolveBalanceDropTarget,
+  type BalanceActiveDrag,
 } from "./balance-editor-helpers";
+import { useBalancerDragGhosts } from "./useBalancerDragGhosts";
 
 type BalanceEditorProps = {
   value: InternalBalancePayload | null;
@@ -35,6 +45,12 @@ type BalanceEditorProps = {
   onSelectPlayer?: (playerId: number | null) => void;
   collapsedTeamIds?: number[];
   onToggleTeam?: (teamId: number) => void;
+  /** Realtime topic for broadcasting live-drag ghosts to other viewers. */
+  realtimeTopic?: string | null;
+  /** Current user's auth id — used to ignore our own broadcast echoes. */
+  currentUserId?: number | null;
+  /** Workspace whose members resolve ghost actor names. */
+  workspaceId?: number | null;
 };
 
 export const BalanceEditor = forwardRef<HTMLDivElement, BalanceEditorProps>(function BalanceEditor(
@@ -46,6 +62,9 @@ export const BalanceEditor = forwardRef<HTMLDivElement, BalanceEditorProps>(func
     onSelectPlayer,
     collapsedTeamIds = [],
     onToggleTeam,
+    realtimeTopic = null,
+    currentUserId = null,
+    workspaceId = null,
   },
   ref,
 ) {
@@ -56,6 +75,41 @@ export const BalanceEditor = forwardRef<HTMLDivElement, BalanceEditorProps>(func
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
   const teamCards = useMemo(() => value?.teams ?? [], [value]);
 
+  const { remoteDrags, broadcastDragStart, broadcastDragOver, broadcastDragEnd } =
+    useBalancerDragGhosts({ topic: realtimeTopic, currentUserId });
+
+  const membersQuery = useQuery({
+    queryKey: ["workspace", "members", workspaceId],
+    queryFn: () => workspaceService.getMembers(workspaceId as number),
+    enabled: workspaceId !== null,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const membersById = useMemo(
+    () =>
+      new Map<number, WorkspaceMember>(
+        (membersQuery.data ?? []).map((member) => [member.auth_user_id, member]),
+      ),
+    [membersQuery.data],
+  );
+
+  const resolveActorName = useCallback(
+    (userId: number) => memberDisplayName(membersById.get(userId), userId),
+    [membersById],
+  );
+
+  const activeDrag = useMemo<BalanceActiveDrag | null>(() => {
+    if (!activePlayer) {
+      return null;
+    }
+    return {
+      currentRole: activePlayer.roleKey,
+      playableRoles: BALANCE_ROSTER_KEYS.filter((role) =>
+        canPlayerPlayRole(activePlayer.player, role),
+      ),
+    };
+  }, [activePlayer]);
+
   if (!value || teamCards.length === 0) {
     return (
       <div className="rounded-2xl border border-white/8 bg-white/2 px-4 py-6 text-sm text-white/45">
@@ -64,12 +118,39 @@ export const BalanceEditor = forwardRef<HTMLDivElement, BalanceEditorProps>(func
     );
   }
 
-  const handleDragStart = (playerId: string) => {
-    setActivePlayer(getDraggedBalancePlayer(value, playerId));
+  const handleDragStart = (event: DragStartEvent) => {
+    const playerId = String(event.active.id);
+    const location = findBalancePlayerLocation(value, playerId);
+    if (!location) {
+      setActivePlayer(null);
+      return;
+    }
+
+    const player = value.teams[location.teamIndex].roster[location.roleKey][location.playerIndex];
+    setActivePlayer({ player, roleKey: location.roleKey });
+    broadcastDragStart({
+      playerId,
+      playerName: player.name,
+      fromTeamIndex: location.teamIndex,
+      fromRoleKey: location.roleKey,
+    });
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    const target = resolveBalanceDropTarget(
+      event.over ? String(event.over.id) : null,
+      event.over?.data.current,
+    );
+    broadcastDragOver({
+      overTeamIndex: target?.teamIndex ?? null,
+      overRoleKey: target?.roleKey ?? null,
+      overInsertIndex: target?.kind === "insert-slot" ? target.insertIndex : null,
+    });
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
     setActivePlayer(null);
+    broadcastDragEnd();
     const nextPayload = moveBalancePlayer(
       value,
       String(event.active.id),
@@ -84,13 +165,20 @@ export const BalanceEditor = forwardRef<HTMLDivElement, BalanceEditorProps>(func
     }
   };
 
+  const handleDragCancel = () => {
+    setActivePlayer(null);
+    broadcastDragEnd();
+  };
+
   const benchedPlayers = value.benched_players ?? [];
 
   return (
     <DndContext
       sensors={sensors}
-      onDragStart={(event) => handleDragStart(String(event.active.id))}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
       <div ref={ref} className="space-y-4">
         {benchedPlayers.length > 0 ? (
@@ -119,6 +207,9 @@ export const BalanceEditor = forwardRef<HTMLDivElement, BalanceEditorProps>(func
               divisionGrid={divisionGrid}
               selectedPlayerId={selectedPlayerId}
               collapsed={collapsedTeamIds.includes(team.id)}
+              activeDrag={activeDrag}
+              remoteDrags={remoteDrags.filter((drag) => drag.overTeamIndex === teamIndex)}
+              resolveActorName={resolveActorName}
               onSelectPlayer={onSelectPlayer}
               onToggleTeam={onToggleTeam}
             />

--- a/frontend/src/components/balancer/BalanceEditorPlayerRows.tsx
+++ b/frontend/src/components/balancer/BalanceEditorPlayerRows.tsx
@@ -57,6 +57,8 @@ type DroppableRoleSectionProps = {
   players: InternalBalancePlayer[];
   divisionGrid: DivisionGrid;
   selectedPlayerId?: number | null;
+  /** The active drag cannot legally drop into this role — block + dim it. */
+  dropDisabled?: boolean;
   onSelectPlayer?: (playerId: number | null) => void;
 };
 
@@ -201,10 +203,12 @@ function BalanceEditorInsertSlotRow({
   teamIndex,
   roleKey,
   insertIndex,
+  disabled = false,
 }: {
   teamIndex: number;
   roleKey: BalancerRosterKey;
   insertIndex: number;
+  disabled?: boolean;
 }) {
   const { setNodeRef, isOver } = useDroppable({
     id: `player-slot:${teamIndex}:${roleKey}:${insertIndex}`,
@@ -214,6 +218,7 @@ function BalanceEditorInsertSlotRow({
       roleKey,
       insertIndex,
     },
+    disabled,
   });
 
   return (
@@ -239,6 +244,7 @@ function DraggableBalanceEditorPlayerTableRow(
     player: InternalBalancePlayer;
     teamIndex: number;
     playerIndex: number;
+    dropDisabled?: boolean;
   },
 ) {
   const { attributes, listeners, setNodeRef: setDraggableNodeRef, transform, isDragging } = useDraggable({
@@ -253,6 +259,7 @@ function DraggableBalanceEditorPlayerTableRow(
       playerIndex: props.playerIndex,
       playerId: props.player.uuid,
     },
+    disabled: props.dropDisabled,
   });
   const style = transform ? { transform: CSS.Translate.toString(transform) } : undefined;
   const setNodeRef = (node: HTMLTableRowElement | null) => {
@@ -279,6 +286,7 @@ export function DroppableRoleSection({
   players,
   divisionGrid,
   selectedPlayerId,
+  dropDisabled = false,
   onSelectPlayer,
 }: DroppableRoleSectionProps) {
   const { setNodeRef, isOver } = useDroppable({
@@ -288,10 +296,18 @@ export function DroppableRoleSection({
       teamIndex,
       roleKey,
     },
+    disabled: dropDisabled,
   });
 
   return (
-    <TableBody ref={setNodeRef} className={cn("transition-colors", isOver && "bg-white/3")}>
+    <TableBody
+      ref={setNodeRef}
+      className={cn(
+        "transition-colors",
+        isOver && "bg-white/3",
+        dropDisabled && "cursor-not-allowed opacity-35",
+      )}
+    >
       {players.map((player, playerIndex) => (
         <Fragment key={player.uuid}>
           <DraggableBalanceEditorPlayerTableRow
@@ -301,6 +317,7 @@ export function DroppableRoleSection({
             roleKey={roleKey}
             divisionGrid={divisionGrid}
             selectedPlayerId={selectedPlayerId}
+            dropDisabled={dropDisabled}
             onSelectPlayer={onSelectPlayer}
           />
           {playerIndex < players.length - 1 ? (
@@ -308,6 +325,7 @@ export function DroppableRoleSection({
               teamIndex={teamIndex}
               roleKey={roleKey}
               insertIndex={playerIndex + 1}
+              disabled={dropDisabled}
             />
           ) : null}
         </Fragment>

--- a/frontend/src/components/balancer/BalanceEditorTeamCard.tsx
+++ b/frontend/src/components/balancer/BalanceEditorTeamCard.tsx
@@ -20,6 +20,8 @@ import type {
 import type { DivisionGrid } from "@/types/workspace.types";
 
 import { DroppableRoleSection } from "./BalanceEditorPlayerRows";
+import { isRoleDropAllowed, type BalanceActiveDrag } from "./balance-editor-helpers";
+import type { RemoteDrag } from "./useBalancerDragGhosts";
 
 type BalanceEditorTeamCardProps = {
   team: InternalBalancePayload["teams"][number];
@@ -27,6 +29,10 @@ type BalanceEditorTeamCardProps = {
   divisionGrid: DivisionGrid;
   selectedPlayerId?: number | null;
   collapsed: boolean;
+  activeDrag?: BalanceActiveDrag | null;
+  /** Other users' in-progress drags currently targeting this team. */
+  remoteDrags?: RemoteDrag[];
+  resolveActorName?: (userId: number) => string;
   onSelectPlayer?: (playerId: number | null) => void;
   onToggleTeam?: (teamId: number) => void;
 };
@@ -36,6 +42,9 @@ export function BalanceEditorTeamCard({
   teamIndex,
   divisionGrid,
   selectedPlayerId,
+  activeDrag = null,
+  remoteDrags = [],
+  resolveActorName,
   onSelectPlayer,
 }: BalanceEditorTeamCardProps) {
   const total = Math.round(calculateTeamTotalFromPayload(team));
@@ -74,6 +83,31 @@ export function BalanceEditorTeamCard({
           
         </div>
       </div>
+      {remoteDrags.length > 0 ? (
+        <div className="flex flex-col gap-1 border-b border-cyan-300/15 bg-cyan-500/5 px-4 py-2">
+          {remoteDrags.map((drag) => (
+            <div
+              key={drag.userId}
+              className="flex items-center gap-1.5 text-[11px] text-cyan-100/80"
+            >
+              <span className="relative flex h-2 w-2 shrink-0">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-cyan-400/70" />
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-cyan-300" />
+              </span>
+              <span className="font-medium text-cyan-50/90">
+                {resolveActorName?.(drag.userId) ?? `User #${drag.userId}`}
+              </span>
+              <span className="text-cyan-100/55">moving</span>
+              <span className="truncate font-medium text-cyan-50/90" title={drag.playerName}>
+                {drag.playerName || "player"}
+              </span>
+              {drag.overRoleKey ? (
+                <span className="text-cyan-100/55">&rarr; {drag.overRoleKey}</span>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
       <Table wrapperClassName="overflow-x-auto overflow-y-visible" className="min-w-90">
         <TableHeader>
           <TableRow className="border-white/6 hover:bg-transparent">
@@ -100,6 +134,7 @@ export function BalanceEditorTeamCard({
             players={team.roster[roleKey]}
             divisionGrid={divisionGrid}
             selectedPlayerId={selectedPlayerId}
+            dropDisabled={activeDrag != null && !isRoleDropAllowed(activeDrag, roleKey)}
             onSelectPlayer={onSelectPlayer}
           />
         ))}

--- a/frontend/src/components/balancer/balance-editor-helpers.test.ts
+++ b/frontend/src/components/balancer/balance-editor-helpers.test.ts
@@ -1,0 +1,285 @@
+import {
+  canPlayerPlayRole,
+  deriveRoleDiscomfort,
+  moveBalancePlayer,
+  type BalanceDropTarget,
+} from "@/components/balancer/balance-editor-helpers";
+import {
+  calculateTeamDiscomfortFromPayload,
+  calculateTeamVarianceFromPayload,
+} from "@/app/balancer/components/balancer-page-helpers";
+import type {
+  BalancerRosterKey,
+  InternalBalancePayload,
+  InternalBalancePlayer,
+} from "@/types/balancer-admin.types";
+
+type TestFunction = () => void | Promise<void>;
+type Expectation<T> = {
+  toBe: (expected: T) => void;
+  toEqual: (expected: unknown) => void;
+  toBeNull: () => void;
+  toBeUndefined: () => void;
+  toBeCloseTo: (expected: number, precision?: number) => void;
+};
+
+declare const describe: (name: string, fn: TestFunction) => void;
+declare const it: (name: string, fn: TestFunction) => void;
+declare const expect: <T>(actual: T) => Expectation<T>;
+
+function makePlayer(overrides: Partial<InternalBalancePlayer> = {}): InternalBalancePlayer {
+  return {
+    uuid: "1",
+    name: "Player",
+    assigned_rating: 3000,
+    role_preferences: ["Tank"],
+    all_ratings: { Tank: 3000 },
+    is_flex: false,
+    role_discomfort: 0,
+    ...overrides,
+  };
+}
+
+function emptyRoster(): Record<BalancerRosterKey, InternalBalancePlayer[]> {
+  return { Tank: [], Damage: [], Support: [] };
+}
+
+function makePayload(
+  teamRosters: Array<Partial<Record<BalancerRosterKey, InternalBalancePlayer[]>>>,
+): InternalBalancePayload {
+  return {
+    teams: teamRosters.map((roster, index) => ({
+      id: index + 1,
+      name: `Team ${index + 1}`,
+      average_mmr: 0,
+      rating_variance: 0,
+      total_discomfort: 0,
+      max_discomfort: 0,
+      roster: { ...emptyRoster(), ...roster },
+    })),
+    statistics: {},
+    benched_players: [],
+  };
+}
+
+describe("canPlayerPlayRole", () => {
+  it("returns true for a role the player has a positive rating for", () => {
+    const player = makePlayer({ all_ratings: { Tank: 3000, Damage: 2800 } });
+    expect(canPlayerPlayRole(player, "Tank")).toBe(true);
+    expect(canPlayerPlayRole(player, "Damage")).toBe(true);
+  });
+
+  it("returns false for a role the player has no rating for", () => {
+    const player = makePlayer({ all_ratings: { Damage: 2800, Support: 2700 } });
+    expect(canPlayerPlayRole(player, "Tank")).toBe(false);
+  });
+
+  it("treats a zero rating as not playable", () => {
+    const player = makePlayer({ all_ratings: { Tank: 0, Damage: 2800 } });
+    expect(canPlayerPlayRole(player, "Tank")).toBe(false);
+  });
+
+  it("falls back to role_preferences when all_ratings is missing", () => {
+    const player = makePlayer({ all_ratings: undefined, role_preferences: ["Damage", "Support"] });
+    expect(canPlayerPlayRole(player, "Damage")).toBe(true);
+    expect(canPlayerPlayRole(player, "Tank")).toBe(false);
+  });
+});
+
+describe("moveBalancePlayer role validation", () => {
+  it("rejects moving a player into a role they cannot play", () => {
+    const support = makePlayer({
+      uuid: "10",
+      role_preferences: ["Support"],
+      all_ratings: { Support: 2700 },
+    });
+    const payload = makePayload([{ Support: [support] }, {}]);
+    const target: BalanceDropTarget = { kind: "role-container", teamIndex: 1, roleKey: "Tank" };
+
+    expect(moveBalancePlayer(payload, "10", target)).toBeNull();
+  });
+
+  it("allows moving a player into a role they can play", () => {
+    const flexTank = makePlayer({
+      uuid: "11",
+      role_preferences: ["Damage", "Tank"],
+      all_ratings: { Damage: 2900, Tank: 2800 },
+    });
+    const payload = makePayload([{ Damage: [flexTank] }, {}]);
+    const target: BalanceDropTarget = { kind: "role-container", teamIndex: 1, roleKey: "Tank" };
+
+    const next = moveBalancePlayer(payload, "11", target);
+    expect(next).not.toBeNull();
+    expect(next?.teams[1].roster.Tank.length).toBe(1);
+    expect(next?.teams[0].roster.Damage.length).toBe(0);
+  });
+
+  it("rejects a swap when the displaced player cannot play the source role", () => {
+    // dragged: Damage main being dropped onto an occupied Tank slot (can play Tank)
+    const draggedDps = makePlayer({
+      uuid: "20",
+      role_preferences: ["Damage", "Tank"],
+      all_ratings: { Damage: 2900, Tank: 2800 },
+    });
+    // occupant: pure Tank who cannot play Damage -> swap into Damage is illegal
+    const occupantTank = makePlayer({
+      uuid: "21",
+      role_preferences: ["Tank"],
+      all_ratings: { Tank: 3100 },
+    });
+    const payload = makePayload([{ Damage: [draggedDps] }, { Tank: [occupantTank] }]);
+    const target: BalanceDropTarget = {
+      kind: "player-row",
+      teamIndex: 1,
+      roleKey: "Tank",
+      playerIndex: 0,
+      playerId: "21",
+    };
+
+    expect(moveBalancePlayer(payload, "20", target)).toBeNull();
+  });
+
+  it("allows a swap when both players can play the swapped roles", () => {
+    const draggedDps = makePlayer({
+      uuid: "30",
+      role_preferences: ["Damage", "Tank"],
+      all_ratings: { Damage: 2900, Tank: 2800 },
+    });
+    const occupantFlex = makePlayer({
+      uuid: "31",
+      role_preferences: ["Tank", "Damage"],
+      all_ratings: { Tank: 3100, Damage: 3000 },
+    });
+    const payload = makePayload([{ Damage: [draggedDps] }, { Tank: [occupantFlex] }]);
+    const target: BalanceDropTarget = {
+      kind: "player-row",
+      teamIndex: 1,
+      roleKey: "Tank",
+      playerIndex: 0,
+      playerId: "31",
+    };
+
+    const next = moveBalancePlayer(payload, "30", target);
+    expect(next).not.toBeNull();
+    expect(next?.teams[1].roster.Tank[0]?.uuid).toBe("30");
+    expect(next?.teams[0].roster.Damage[0]?.uuid).toBe("31");
+  });
+
+  it("allows reordering within the same role bucket regardless of other roles", () => {
+    const a = makePlayer({ uuid: "40", role_preferences: ["Damage"], all_ratings: { Damage: 2900 } });
+    const b = makePlayer({ uuid: "41", role_preferences: ["Damage"], all_ratings: { Damage: 2800 } });
+    const payload = makePayload([{ Damage: [a, b] }]);
+    const target: BalanceDropTarget = {
+      kind: "player-row",
+      teamIndex: 0,
+      roleKey: "Damage",
+      playerIndex: 0,
+      playerId: "40",
+    };
+
+    const next = moveBalancePlayer(payload, "41", target);
+    expect(next).not.toBeNull();
+    expect(next?.teams[0].roster.Damage[0]?.uuid).toBe("41");
+  });
+});
+
+describe("deriveRoleDiscomfort", () => {
+  it("returns 0 for a flex player on a playable role", () => {
+    const player = makePlayer({ is_flex: true, all_ratings: { Tank: 3000, Damage: 2900 } });
+    expect(deriveRoleDiscomfort(player, "Damage")).toBe(0);
+  });
+
+  it("returns 0 for the primary role and 100 per preference step", () => {
+    const player = makePlayer({
+      is_flex: false,
+      role_preferences: ["Tank", "Damage", "Support"],
+      all_ratings: { Tank: 3000, Damage: 2900, Support: 2800 },
+    });
+    expect(deriveRoleDiscomfort(player, "Tank")).toBe(0);
+    expect(deriveRoleDiscomfort(player, "Damage")).toBe(100);
+    expect(deriveRoleDiscomfort(player, "Support")).toBe(200);
+  });
+
+  it("returns 1000 for a playable off-preference role, 5000 for an unplayable role", () => {
+    const player = makePlayer({
+      is_flex: false,
+      role_preferences: ["Damage"],
+      all_ratings: { Damage: 2900, Support: 2700 },
+    });
+    expect(deriveRoleDiscomfort(player, "Support")).toBe(1000);
+    expect(deriveRoleDiscomfort(player, "Tank")).toBe(5000);
+  });
+});
+
+describe("moveBalancePlayer rank + discomfort recompute", () => {
+  it("re-rates the player for the new role and keeps original preference order", () => {
+    const dps = makePlayer({
+      uuid: "50",
+      role_preferences: ["Damage", "Tank"],
+      all_ratings: { Damage: 2900, Tank: 2800 },
+      all_discomforts: { Damage: 0, Tank: 100 },
+      assigned_rating: 2900,
+      role_discomfort: 0,
+    });
+    const payload = makePayload([{ Damage: [dps] }, {}]);
+    const target: BalanceDropTarget = { kind: "role-container", teamIndex: 1, roleKey: "Tank" };
+
+    const next = moveBalancePlayer(payload, "50", target);
+    expect(next).not.toBeNull();
+    const moved = next?.teams[1].roster.Tank[0];
+    expect(moved?.assigned_rating).toBe(2800);
+    expect(moved?.role_discomfort).toBe(100);
+    // Preferences are NOT reordered (true primary remains first).
+    expect(moved?.role_preferences).toEqual(["Damage", "Tank"]);
+    expect(next?.teams[1].average_mmr).toBeCloseTo(2800, 5);
+    expect(next?.teams[0].average_mmr).toBeCloseTo(0, 5);
+  });
+
+  it("derives discomfort when all_discomforts is absent (legacy payload)", () => {
+    const dps = makePlayer({
+      uuid: "51",
+      role_preferences: ["Damage"],
+      all_ratings: { Damage: 2900, Tank: 2800 },
+      all_discomforts: undefined,
+      assigned_rating: 2900,
+    });
+    const payload = makePayload([{ Damage: [dps] }, {}]);
+    const target: BalanceDropTarget = { kind: "role-container", teamIndex: 1, roleKey: "Tank" };
+
+    const next = moveBalancePlayer(payload, "51", target);
+    const moved = next?.teams[1].roster.Tank[0];
+    expect(moved?.assigned_rating).toBe(2800);
+    expect(moved?.role_discomfort).toBe(1000); // playable off-preference
+  });
+});
+
+describe("team variance + discomfort recompute", () => {
+  it("computes sample stdev of assigned ratings and discomfort total/max", () => {
+    const payload = makePayload([
+      {
+        Tank: [makePlayer({ uuid: "60", assigned_rating: 3000, role_discomfort: 0 })],
+        Damage: [
+          makePlayer({ uuid: "61", assigned_rating: 2800, role_discomfort: 0 }),
+          makePlayer({ uuid: "62", assigned_rating: 2600, role_discomfort: 100 }),
+        ],
+        Support: [
+          makePlayer({ uuid: "63", assigned_rating: 2700, role_discomfort: 0 }),
+          makePlayer({ uuid: "64", assigned_rating: 2500, role_discomfort: 1000 }),
+        ],
+      },
+    ]);
+    const team = payload.teams[0];
+
+    // ratings [3000,2800,2600,2700,2500], mean 2720, sample variance 37000 -> stdev ~192.354
+    expect(calculateTeamVarianceFromPayload(team)).toBeCloseTo(192.35, 1);
+
+    const discomfort = calculateTeamDiscomfortFromPayload(team);
+    expect(discomfort.total).toBe(1100);
+    expect(discomfort.max).toBe(1000);
+  });
+
+  it("returns 0 variance for a single-player team", () => {
+    const payload = makePayload([{ Tank: [makePlayer({ uuid: "70", assigned_rating: 3000 })] }]);
+    expect(calculateTeamVarianceFromPayload(payload.teams[0])).toBe(0);
+  });
+});

--- a/frontend/src/components/balancer/balance-editor-helpers.ts
+++ b/frontend/src/components/balancer/balance-editor-helpers.ts
@@ -5,7 +5,14 @@ import type {
 } from "@/types/balancer-admin.types";
 
 import {
+  calculateOffRoleCountFromPayload,
+  calculateSubRoleCollisionsFromPayload,
   calculateTeamAverageValueFromPayload,
+  calculateTeamDiscomfortFromPayload,
+  calculateTeamTotalFromPayload,
+  calculateTeamVarianceFromPayload,
+  countTeamPlayers,
+  sampleStdDev,
 } from "@/app/balancer/components/balancer-page-helpers";
 
 export const BALANCE_EDITOR_ROLE_CAPACITY: Record<BalancerRosterKey, number> = {
@@ -31,6 +38,27 @@ export type BalancePlayerLocation = {
   roleKey: BalancerRosterKey;
   playerIndex: number;
 };
+
+/** The currently dragged player's role context, used to gate drop targets in the UI. */
+export type BalanceActiveDrag = {
+  currentRole: BalancerRosterKey;
+  playableRoles: BalancerRosterKey[];
+};
+
+/**
+ * Whether dropping the active drag onto `roleKey` is allowed: the player's own
+ * role is always valid (same-role / cross-team move), any other role only if
+ * the player can play it.
+ */
+export function isRoleDropAllowed(
+  activeDrag: BalanceActiveDrag | null,
+  roleKey: BalancerRosterKey,
+): boolean {
+  if (!activeDrag) {
+    return true;
+  }
+  return roleKey === activeDrag.currentRole || activeDrag.playableRoles.includes(roleKey);
+}
 
 export type BalanceDropTarget =
   | {
@@ -158,6 +186,23 @@ export function getDraggedBalancePlayer(
   };
 }
 
+/**
+ * Whether a player is eligible to occupy a given role slot. Mirrors the
+ * backend `Player.can_play` (a role is playable iff the player has a positive
+ * rating for it). Falls back to declared `role_preferences` for legacy payloads
+ * that predate `all_ratings`.
+ */
+export function canPlayerPlayRole(
+  player: InternalBalancePlayer,
+  roleKey: BalancerRosterKey,
+): boolean {
+  const ratings = player.all_ratings;
+  if (ratings && Object.keys(ratings).length > 0) {
+    return (ratings[roleKey] ?? 0) > 0;
+  }
+  return player.role_preferences.includes(roleKey);
+}
+
 export function moveBalancePlayer(
   payload: InternalBalancePayload,
   activeId: string,
@@ -205,7 +250,11 @@ export function moveBalancePlayer(
         return null;
       }
 
-      applyAssignedRolePreference(player, target.roleKey);
+      if (from.roleKey !== target.roleKey && !canPlayerPlayRole(player, target.roleKey)) {
+        return null;
+      }
+
+      assignPlayerToRole(player, target.roleKey);
     }
 
     targetPlayers.splice(Math.min(insertIndex, targetPlayers.length), 0, player);
@@ -228,7 +277,11 @@ export function moveBalancePlayer(
     }
 
     if (targetPlayers.length < BALANCE_EDITOR_ROLE_CAPACITY[target.roleKey]) {
-      applyAssignedRolePreference(player, target.roleKey);
+      if (from.roleKey !== target.roleKey && !canPlayerPlayRole(player, target.roleKey)) {
+        return null;
+      }
+
+      assignPlayerToRole(player, target.roleKey);
       targetPlayers.splice(Math.min(target.playerIndex, targetPlayers.length), 0, player);
       return recalculateBalancePayloadStats(next);
     }
@@ -238,10 +291,20 @@ export function moveBalancePlayer(
       return null;
     }
 
+    // Swap across different roles: both players change role, so both must be
+    // eligible for the role they land in.
+    if (
+      from.roleKey !== target.roleKey &&
+      (!canPlayerPlayRole(player, target.roleKey) ||
+        !canPlayerPlayRole(targetPlayer, from.roleKey))
+    ) {
+      return null;
+    }
+
     targetPlayers.splice(target.playerIndex, 1, player);
     sourcePlayers.splice(from.playerIndex, 0, targetPlayer);
-    applyAssignedRolePreference(player, target.roleKey);
-    applyAssignedRolePreference(targetPlayer, from.roleKey);
+    assignPlayerToRole(player, target.roleKey);
+    assignPlayerToRole(targetPlayer, from.roleKey);
     return recalculateBalancePayloadStats(next);
   }
 
@@ -258,37 +321,114 @@ export function moveBalancePlayer(
     return null;
   }
 
-  applyAssignedRolePreference(player, target.roleKey);
+  if (from.roleKey !== target.roleKey && !canPlayerPlayRole(player, target.roleKey)) {
+    return null;
+  }
+
+  assignPlayerToRole(player, target.roleKey);
   targetPlayers.push(player);
 
   return recalculateBalancePayloadStats(next);
 }
 
-function applyAssignedRolePreference(
+/**
+ * Per-role discomfort, derived the same way the backend builds `discomfort_map`
+ * (entities.py): flex players are comfortable on any role they can play; an
+ * in-preference role costs 100 per step down the list; an off-preference role
+ * costs 1000 if playable, 5000 if not. Used as a fallback when the solver's
+ * `all_discomforts` snapshot is absent (legacy payloads).
+ */
+export function deriveRoleDiscomfort(
   player: InternalBalancePlayer,
   roleKey: BalancerRosterKey,
-) {
-  player.role_preferences = [
-    roleKey,
-    ...player.role_preferences.filter((preference) => preference !== roleKey),
-  ];
+): number {
+  const playable = canPlayerPlayRole(player, roleKey);
+  if (player.is_flex && playable) {
+    return 0;
+  }
+  const preferenceIndex = player.role_preferences.indexOf(roleKey);
+  if (preferenceIndex >= 0) {
+    return preferenceIndex * 100;
+  }
+  return playable ? 1000 : 5000;
+}
+
+/**
+ * Re-rate a player for the role bucket they now occupy. Unlike the previous
+ * `applyAssignedRolePreference`, this does NOT reorder `role_preferences`
+ * (the original order is the source of truth for primary role + discomfort);
+ * the assigned role is implied by the roster bucket. `assigned_rating` and
+ * `role_discomfort` are snapped to the new role's values.
+ */
+function assignPlayerToRole(player: InternalBalancePlayer, roleKey: BalancerRosterKey): void {
+  const rating = player.all_ratings?.[roleKey];
+  if (typeof rating === "number" && rating > 0) {
+    player.assigned_rating = rating;
+  }
+  player.role_discomfort = player.all_discomforts?.[roleKey] ?? deriveRoleDiscomfort(player, roleKey);
 }
 
 function recalculateBalancePayloadStats(
   next: InternalBalancePayload,
 ): InternalBalancePayload {
-  next.teams = next.teams.map((team) => ({
-    ...team,
-    average_mmr: calculateTeamAverageValueFromPayload(team),
-  }));
+  next.teams = next.teams.map((team) => {
+    const discomfort = calculateTeamDiscomfortFromPayload(team);
+    return {
+      ...team,
+      average_mmr: calculateTeamAverageValueFromPayload(team),
+      rating_variance: calculateTeamVarianceFromPayload(team),
+      total_discomfort: discomfort.total,
+      max_discomfort: discomfort.max,
+    };
+  });
 
-  if (next.statistics) {
-    next.statistics.average_mmr =
-      next.teams.reduce(
-        (sum, team) => sum + calculateTeamAverageValueFromPayload(team),
-        0,
-      ) / next.teams.length;
+  next.statistics = recalculateBalanceStatistics(next);
+  return next;
+}
+
+/**
+ * Recompute the aggregate statistics block from the current rosters, mirroring
+ * `result_serializer.teams_to_json`. Solver-only objective scores
+ * (balance/comfort/composite) cannot be recomputed client-side and are
+ * preserved from the previous statistics (they reflect the original solve).
+ */
+function recalculateBalanceStatistics(
+  payload: InternalBalancePayload,
+): InternalBalancePayload["statistics"] {
+  const previous = payload.statistics ?? {};
+  const teams = payload.teams;
+  if (teams.length === 0) {
+    return previous;
   }
 
-  return next;
+  const teamAverages = teams.map((team) => calculateTeamAverageValueFromPayload(team));
+  const teamTotals = teams.map((team) => calculateTeamTotalFromPayload(team));
+  const totalPlaced = teams.reduce((sum, team) => sum + countTeamPlayers(team), 0);
+  const offRoleCount = teams.reduce(
+    (sum, team) => sum + calculateOffRoleCountFromPayload(team),
+    0,
+  );
+  const subRoleCollisions = teams.reduce(
+    (sum, team) => sum + calculateSubRoleCollisionsFromPayload(team),
+    0,
+  );
+
+  return {
+    ...previous,
+    average_mmr: mean(teamAverages),
+    mmr_std_dev: sampleStdDev(teamAverages),
+    average_total_rating: mean(teamTotals),
+    total_rating_std_dev: sampleStdDev(teamTotals),
+    max_total_rating_gap: teamTotals.length > 0 ? Math.max(...teamTotals) - Math.min(...teamTotals) : 0,
+    off_role_count: offRoleCount,
+    off_role_rate: totalPlaced > 0 ? offRoleCount / totalPlaced : 0,
+    sub_role_collision_count: subRoleCollisions,
+  };
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
 }

--- a/frontend/src/components/balancer/useBalancerDragGhosts.test.ts
+++ b/frontend/src/components/balancer/useBalancerDragGhosts.test.ts
@@ -1,0 +1,86 @@
+import {
+  applyDragEvent,
+  pruneStaleDrags,
+  type DragEventData,
+  type RemoteDrag,
+} from "@/components/balancer/useBalancerDragGhosts";
+
+type TestFunction = () => void | Promise<void>;
+type Expectation<T> = {
+  toBe: (expected: T) => void;
+  toEqual: (expected: unknown) => void;
+  toBeUndefined: () => void;
+};
+
+declare const describe: (name: string, fn: TestFunction) => void;
+declare const it: (name: string, fn: TestFunction) => void;
+declare const expect: <T>(actual: T) => Expectation<T>;
+
+const startData: DragEventData = {
+  phase: "start",
+  player_id: "7",
+  player_name: "Echo",
+  from_team_index: 0,
+  from_role_key: "Damage",
+};
+
+const overData: DragEventData = {
+  ...startData,
+  phase: "over",
+  over_team_index: 1,
+  over_role_key: "Tank",
+  over_insert_index: null,
+};
+
+describe("applyDragEvent", () => {
+  it("ignores frames from the current user", () => {
+    const result = applyDragEvent({}, 5, startData, 5, 1000);
+    expect(result).toEqual({});
+  });
+
+  it("ignores frames with no actor", () => {
+    const result = applyDragEvent({}, null, startData, 5, 1000);
+    expect(result).toEqual({});
+  });
+
+  it("adds a ghost on start and updates it on over", () => {
+    const afterStart = applyDragEvent({}, 9, startData, 5, 1000);
+    expect(afterStart[9]?.playerName).toBe("Echo");
+    expect(afterStart[9]?.overTeamIndex).toBe(null);
+
+    const afterOver = applyDragEvent(afterStart, 9, overData, 5, 1100);
+    expect(afterOver[9]?.overTeamIndex).toBe(1);
+    expect(afterOver[9]?.overRoleKey).toBe("Tank");
+    expect(afterOver[9]?.updatedAt).toBe(1100);
+  });
+
+  it("removes the ghost on end", () => {
+    const afterStart = applyDragEvent({}, 9, startData, 5, 1000);
+    const afterEnd = applyDragEvent(afterStart, 9, { phase: "end" }, 5, 1200);
+    expect(afterEnd[9]).toBeUndefined();
+  });
+
+  it("returns the same map when ending an unknown drag", () => {
+    const drags: Record<number, RemoteDrag> = {};
+    const result = applyDragEvent(drags, 9, { phase: "end" }, 5, 1200);
+    expect(result).toBe(drags);
+  });
+});
+
+describe("pruneStaleDrags", () => {
+  it("drops ghosts older than the TTL and keeps fresh ones", () => {
+    const drags = {
+      ...applyDragEvent({}, 1, startData, 99, 1000),
+      ...applyDragEvent({}, 2, startData, 99, 5000),
+    };
+    const pruned = pruneStaleDrags(drags, 5500, 2000);
+    expect(pruned[1]).toBeUndefined();
+    expect(pruned[2]?.userId).toBe(2);
+  });
+
+  it("returns the same reference when nothing is stale", () => {
+    const drags = applyDragEvent({}, 1, startData, 99, 5000);
+    const pruned = pruneStaleDrags(drags, 5500, 2000);
+    expect(pruned).toBe(drags);
+  });
+});

--- a/frontend/src/components/balancer/useBalancerDragGhosts.ts
+++ b/frontend/src/components/balancer/useBalancerDragGhosts.ts
@@ -1,0 +1,227 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useRealtimeTopic } from "@/hooks/useRealtimeTopic";
+import { realtimeClient } from "@/services/realtime.service";
+import type { RealtimeEventEnvelope } from "@/types/realtime.types";
+import type { BalancerRosterKey } from "@/types/balancer-admin.types";
+
+/** Mirrors `BALANCER_DRAG` in shared/services/balancer_realtime.py. */
+export const BALANCER_DRAG_EVENT = "balancer.drag";
+
+/** A ghost expires if no frame arrives within this window (covers missed `end` / disconnect). */
+const GHOST_TTL_MS = 2000;
+/** Min interval between outgoing `over` frames while dragging. */
+const OVER_THROTTLE_MS = 40;
+
+export type DragPhase = "start" | "over" | "end";
+
+/** Identity of the dragged player + its origin, set on drag start. */
+export type DragStartPayload = {
+  playerId: string;
+  playerName: string;
+  fromTeamIndex: number;
+  fromRoleKey: BalancerRosterKey;
+};
+
+/** The slot the dragged card currently hovers (semantic, not pixel coords). */
+export type DragOverPayload = {
+  overTeamIndex: number | null;
+  overRoleKey: BalancerRosterKey | null;
+  overInsertIndex: number | null;
+};
+
+/** A remote user's in-progress drag, resolved for rendering a ghost. */
+export type RemoteDrag = DragStartPayload &
+  DragOverPayload & {
+    userId: number;
+    updatedAt: number;
+  };
+
+/** Max length of a remote-supplied player name we keep (defensive bound on untrusted text). */
+const MAX_PLAYER_NAME_LENGTH = 80;
+
+/** Wire shape of a `balancer.drag` event payload (snake_case to match the backend). */
+export type DragEventData = {
+  phase: DragPhase;
+  player_id?: string;
+  player_name?: string;
+  from_team_index?: number;
+  from_role_key?: BalancerRosterKey;
+  over_team_index?: number | null;
+  over_role_key?: BalancerRosterKey | null;
+  over_insert_index?: number | null;
+};
+
+type RemoteDragMap = Record<number, RemoteDrag>;
+
+/**
+ * Fold an incoming drag event into the ghost map. `start`/`over` frames carry the
+ * full player identity (so a late-joining `over` needs no prior `start`); `end`
+ * removes the ghost. Frames from `currentUserId` and frames without an actor are
+ * ignored (the local user renders their own drag directly).
+ */
+export function applyDragEvent(
+  drags: RemoteDragMap,
+  actorUserId: number | null,
+  data: DragEventData,
+  currentUserId: number | null,
+  nowMs: number,
+): RemoteDragMap {
+  if (actorUserId == null || actorUserId === currentUserId) {
+    return drags;
+  }
+
+  if (data.phase === "end") {
+    if (!(actorUserId in drags)) {
+      return drags;
+    }
+    const next = { ...drags };
+    delete next[actorUserId];
+    return next;
+  }
+
+  return {
+    ...drags,
+    [actorUserId]: {
+      userId: actorUserId,
+      playerId: data.player_id ?? "",
+      playerName: (data.player_name ?? "").slice(0, MAX_PLAYER_NAME_LENGTH),
+      fromTeamIndex: data.from_team_index ?? 0,
+      fromRoleKey: data.from_role_key ?? "Tank",
+      overTeamIndex: data.over_team_index ?? null,
+      overRoleKey: data.over_role_key ?? null,
+      overInsertIndex: data.over_insert_index ?? null,
+      updatedAt: nowMs,
+    },
+  };
+}
+
+/** Drop ghosts that have not been refreshed within the TTL. */
+export function pruneStaleDrags(drags: RemoteDragMap, nowMs: number, ttlMs = GHOST_TTL_MS): RemoteDragMap {
+  const entries = Object.values(drags).filter((drag) => nowMs - drag.updatedAt <= ttlMs);
+  if (entries.length === Object.keys(drags).length) {
+    return drags;
+  }
+  return Object.fromEntries(entries.map((drag) => [drag.userId, drag]));
+}
+
+type UseBalancerDragGhostsResult = {
+  remoteDrags: RemoteDrag[];
+  broadcastDragStart: (payload: DragStartPayload) => void;
+  broadcastDragOver: (over: DragOverPayload) => void;
+  broadcastDragEnd: () => void;
+};
+
+/**
+ * Live-drag overlay: subscribes to `balancer.drag` on the tournament topic to
+ * collect other users' in-progress drags (as ghosts) and exposes throttled
+ * publishers to broadcast the local user's drag. Purely a visibility layer —
+ * it never mutates roster state.
+ */
+export function useBalancerDragGhosts({
+  topic,
+  currentUserId,
+}: {
+  topic: string | null;
+  currentUserId: number | null;
+}): UseBalancerDragGhostsResult {
+  const [drags, setDrags] = useState<RemoteDragMap>({});
+  const [trackedTopic, setTrackedTopic] = useState(topic);
+  const startPayloadRef = useRef<DragStartPayload | null>(null);
+  const lastOverSentRef = useRef(0);
+
+  // Reset ghosts when the topic changes, using the render-phase "adjust state on
+  // prop change" pattern (cheaper and lint-clean vs. a setState-in-effect reset).
+  if (topic !== trackedTopic) {
+    setTrackedTopic(topic);
+    setDrags({});
+  }
+
+  const handleEvent = useCallback(
+    (event: RealtimeEventEnvelope<DragEventData>) => {
+      if (event.event_type !== BALANCER_DRAG_EVENT) {
+        return;
+      }
+      setDrags((prev) => applyDragEvent(prev, event.actor_user_id, event.data, currentUserId, Date.now()));
+    },
+    [currentUserId],
+  );
+
+  useRealtimeTopic(topic, handleEvent);
+
+  // Periodically prune ghosts whose owner stopped sending frames (missed `end`
+  // or disconnect). Ref resets here cover the topic switch handled above.
+  useEffect(() => {
+    startPayloadRef.current = null;
+    lastOverSentRef.current = 0;
+    if (!topic) {
+      return;
+    }
+    const interval = setInterval(() => {
+      setDrags((prev) => pruneStaleDrags(prev, Date.now()));
+    }, 500);
+    return () => clearInterval(interval);
+  }, [topic]);
+
+  const broadcastDragStart = useCallback(
+    (payload: DragStartPayload) => {
+      startPayloadRef.current = payload;
+      lastOverSentRef.current = 0;
+      if (!topic) {
+        return;
+      }
+      realtimeClient.publish(topic, BALANCER_DRAG_EVENT, serializeDrag("start", payload, null));
+    },
+    [topic],
+  );
+
+  const broadcastDragOver = useCallback(
+    (over: DragOverPayload) => {
+      const start = startPayloadRef.current;
+      if (!topic || !start) {
+        return;
+      }
+      const now = Date.now();
+      if (now - lastOverSentRef.current < OVER_THROTTLE_MS) {
+        return;
+      }
+      lastOverSentRef.current = now;
+      realtimeClient.publish(topic, BALANCER_DRAG_EVENT, serializeDrag("over", start, over));
+    },
+    [topic],
+  );
+
+  const broadcastDragEnd = useCallback(() => {
+    startPayloadRef.current = null;
+    if (!topic) {
+      return;
+    }
+    realtimeClient.publish(topic, BALANCER_DRAG_EVENT, { phase: "end" });
+  }, [topic]);
+
+  return {
+    remoteDrags: Object.values(drags),
+    broadcastDragStart,
+    broadcastDragOver,
+    broadcastDragEnd,
+  };
+}
+
+function serializeDrag(
+  phase: DragPhase,
+  start: DragStartPayload,
+  over: DragOverPayload | null,
+): Record<string, unknown> {
+  return {
+    phase,
+    player_id: start.playerId,
+    player_name: start.playerName,
+    from_team_index: start.fromTeamIndex,
+    from_role_key: start.fromRoleKey,
+    over_team_index: over?.overTeamIndex ?? null,
+    over_role_key: over?.overRoleKey ?? null,
+    over_insert_index: over?.overInsertIndex ?? null,
+  };
+}

--- a/frontend/src/lib/workspace-member.ts
+++ b/frontend/src/lib/workspace-member.ts
@@ -1,0 +1,13 @@
+import type { WorkspaceMember } from "@/types/workspace.types";
+
+/**
+ * Human-readable name for a workspace member, with graceful fallbacks:
+ * full name -> username -> email -> `User #<id>`.
+ */
+export function memberDisplayName(member: WorkspaceMember | undefined, userId: number): string {
+  if (!member) {
+    return `User #${userId}`;
+  }
+  const fullName = [member.first_name, member.last_name].filter(Boolean).join(" ").trim();
+  return fullName || member.username || member.email || `User #${userId}`;
+}

--- a/frontend/src/services/realtime.service.ts
+++ b/frontend/src/services/realtime.service.ts
@@ -97,6 +97,19 @@ class RealtimeClient {
     this.sendSubscribe(topic);
   }
 
+  /**
+   * Publish an ephemeral frame to a topic (e.g. a live-drag overlay). Fire and
+   * forget: silently dropped when the socket is not open, since these frames are
+   * transient and losing one is harmless. The server stamps the actor, enforces
+   * the topic ACL, and restricts which event types clients may publish.
+   */
+  publish(topic: string, eventType: string, data: Record<string, unknown>): void {
+    if (typeof window === "undefined") {
+      return;
+    }
+    this.send({ op: "publish", topic, event_type: eventType, data });
+  }
+
   private ensureSocket(): void {
     if (this.socket?.readyState === WebSocket.OPEN || this.socket?.readyState === WebSocket.CONNECTING) {
       return;

--- a/frontend/src/types/balancer-admin.types.ts
+++ b/frontend/src/types/balancer-admin.types.ts
@@ -81,6 +81,8 @@ export interface InternalBalancePlayer {
   role_preferences: string[];
   sub_role?: BalancerRoleSubtype | null;
   all_ratings?: Record<string, number>;
+  /** Stable per-role discomfort snapshot from the solver (immune to UI reordering). */
+  all_discomforts?: Record<string, number>;
 }
 
 export interface InternalBalanceTeam {

--- a/frontend/src/types/realtime.types.ts
+++ b/frontend/src/types/realtime.types.ts
@@ -28,7 +28,15 @@ export type PingOp = {
   op: "ping";
 };
 
-export type ClientRealtimeFrame = SubscribeOp | UnsubscribeOp | PingOp;
+/** Client-originated ephemeral broadcast to a subscribed topic (e.g. live drag). */
+export type PublishOp = {
+  op: "publish";
+  topic: string;
+  event_type: string;
+  data: Record<string, unknown>;
+};
+
+export type ClientRealtimeFrame = SubscribeOp | UnsubscribeOp | PingOp | PublishOp;
 
 export type SubscribedFrame = {
   op: "subscribed";


### PR DESCRIPTION
…rag ghosts

Improve the balance preview drag-and-drop editor:

- Validate role eligibility on drop: block moving a player onto a role they cannot play (mirrors backend Player.can_play); invalid drop targets are disabled in the UI. Swaps validate both players.
- Recompute stats on move: re-rate the moved player (assigned_rating / role_discomfort) from per-role maps and recompute team avg / variance / discomfort and global statistics client-side. assignPlayerToRole no longer reorders role_preferences (assigned role is derived from the roster bucket), fixing discomfort and off-role detection. Backend serializes a stable all_discomforts snapshot.
- Realtime live-drag ghosts: new client->server ephemeral WS publish op fanned out to co-subscribers. Hardened: auth-only, topic must be subscribed (inherits ACL), event-type allowlist (balancer.drag), server-stamped actor, event_id=0, sender excluded, 60/s rate limit, bounded data + frame size. Frontend useBalancerDragGhosts hook renders ghost chips per target team.

Tests: 60 frontend (bun), 24 realtime-service, 82 balancer-service.