### PR TITLE
feat(users): restore lost UX and port mockup features on player profile

### DIFF
--- a/frontend/src/app/(site)/users/components/UserHeader.tsx
+++ b/frontend/src/app/(site)/users/components/UserHeader.tsx
@@ -6,6 +6,7 @@ import { getPlayerImage } from "@/utils/player";
 import DivisionIcon from "@/components/DivisionIcon";
 import PlayerRoleIcon from "@/components/PlayerRoleIcon";
 import { FormStreak, type FormResult } from "@/app/(site)/users/components/redesign/atoms";
+import ProfileToolbar from "@/app/(site)/users/components/redesign/ProfileToolbar";
 import userService from "@/services/user.service";
 
 export interface UserHeaderProps {
@@ -42,16 +43,6 @@ const primaryRoleOf = (profile: UserProfile) => {
   return profile.roles.reduce((best, current) => (current.tournaments > best.tournaments ? current : best));
 };
 
-const auraLabel = (profile: UserProfile): string | null => {
-  const role = primaryRoleOf(profile);
-  if (!role) return null;
-  const division = role.division;
-  if (division >= 16) return `${role.role} · Div ${division} · Anchor`;
-  if (division >= 11) return `Top ${role.role} · Div ${division}`;
-  if (division >= 6) return `${role.role} core · Div ${division}`;
-  return `Rising ${role.role} · Div ${division}`;
-};
-
 const UserHeader = async ({ profile, user }: UserHeaderProps) => {
   const [name, tag] = user.name.split("#");
   const primaryRole = primaryRoleOf(profile);
@@ -59,7 +50,6 @@ const UserHeader = async ({ profile, user }: UserHeaderProps) => {
 
   const winrate = profile.maps_total > 0 ? (profile.maps_won / profile.maps_total) * 100 : null;
   const formStreak = await deriveFormStreak(user.id);
-  const aura = auraLabel(profile);
   const roleSwatchColor =
     primaryRole?.role === "Tank"
       ? "var(--aqt-tank)"
@@ -86,11 +76,14 @@ const UserHeader = async ({ profile, user }: UserHeaderProps) => {
         style={{ background: "radial-gradient(ellipse at 70% 40%, hsl(174 72% 46% / 0.12), transparent 58%)" }}
       />
 
-      <p className="relative z-[1] px-9 pt-5 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--aqt-fg-faint)]">
-        <Link href="/users" className="hover:text-[color:var(--aqt-fg-muted)]">Users</Link>
-        <span className="mx-1">·</span>
-        <span className="text-[color:var(--aqt-fg-muted)]">{name}</span>
-      </p>
+      <div className="relative z-[1] flex items-center justify-between gap-3 px-9 pt-5">
+        <p className="m-0 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--aqt-fg-faint)]">
+          <Link href="/users" className="hover:text-[color:var(--aqt-fg-muted)]">Users</Link>
+          <span className="mx-1">·</span>
+          <span className="text-[color:var(--aqt-fg-muted)]">{name}</span>
+        </p>
+        <ProfileToolbar />
+      </div>
 
       <div className="relative z-[1] grid items-center gap-8 p-7 pt-6 md:grid-cols-[auto_1fr_auto] md:px-9 md:py-7">
         <div className="relative h-[110px] w-[110px] flex-shrink-0">
@@ -217,18 +210,6 @@ const UserHeader = async ({ profile, user }: UserHeaderProps) => {
             ) : (
               <span className="aqt-mono text-[11px] text-[color:var(--aqt-fg-dim)]">No recent matches</span>
             )}
-            {aura ? (
-              <span
-                className="ml-auto inline-flex items-center gap-2 rounded-lg px-2.5 py-1"
-                style={{
-                  background: "hsl(38 95% 55% / 0.08)",
-                  border: "1px solid hsl(38 95% 55% / 0.25)"
-                }}
-              >
-                <span className="aqt-mono text-[10px] font-bold tracking-[0.1em] text-[color:var(--aqt-amber)]">AURA</span>
-                <span className="text-xs font-semibold text-[color:var(--aqt-fg)]">{aura}</span>
-              </span>
-            ) : null}
           </div>
         </div>
       </div>

--- a/frontend/src/app/(site)/users/components/redesign/AchievementsView.tsx
+++ b/frontend/src/app/(site)/users/components/redesign/AchievementsView.tsx
@@ -59,6 +59,7 @@ const AchievementsView = ({ achievements, tournaments = [], selectedTournamentVa
 
   const [rarityFilter, setRarityFilter] = useState<Rarity | null>(null);
   const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<"rarity" | "name" | "count">("rarity");
 
   const uniqueTournaments = useMemo(() => {
     const seen = new Set<number>();
@@ -120,10 +121,15 @@ const AchievementsView = ({ achievements, tournaments = [], selectedTournamentVa
           (a.description_ru?.toLowerCase().includes(q))
         );
       }
-      return list;
+      const sorted = [...list].sort((a, b) => {
+        if (sort === "name") return (a.name ?? "").localeCompare(b.name ?? "");
+        if (sort === "count") return b.count - a.count;
+        return a.rarity - b.rarity; // rarest first
+      });
+      return sorted;
     };
     return Object.fromEntries(RARITY_ORDER.map((r) => [r, filteredEntry(r)])) as Record<Rarity, AchievementRarity[]>;
-  }, [grouped, rarityFilter, search]);
+  }, [grouped, rarityFilter, search, sort]);
 
   return (
     <div className="aqt-player flex flex-col gap-3.5">
@@ -178,6 +184,16 @@ const AchievementsView = ({ achievements, tournaments = [], selectedTournamentVa
             </SelectContent>
           </Select>
         )}
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value as "rarity" | "name" | "count")}
+          title="Sort achievements"
+          className="aqt-mono cursor-pointer rounded-lg border border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.02)] px-2.5 py-1.5 text-[12px] text-[color:var(--aqt-fg)] outline-none"
+        >
+          <option value="rarity" className="bg-[#10151c]">Sort: Rarity</option>
+          <option value="name" className="bg-[#10151c]">Sort: Name</option>
+          <option value="count" className="bg-[#10151c]">Sort: Earned</option>
+        </select>
         <div className="filter-search relative ml-auto min-w-[200px] max-w-[300px] flex-1">
           <input
             placeholder="Search achievements…"

--- a/frontend/src/app/(site)/users/components/redesign/HeroesView.tsx
+++ b/frontend/src/app/(site)/users/components/redesign/HeroesView.tsx
@@ -15,6 +15,7 @@ import HeroImage from "@/components/hero/HeroImage";
 import {
   computeDelta,
   formatDelta,
+  formatPercent,
   formatSeconds,
   formatStatValue,
   getOverall,
@@ -25,6 +26,23 @@ interface Props {
   heroes: HeroWithUserStats[];
   filterSlot?: React.ReactNode;
 }
+
+type StatSortKey = "delta" | "overall" | "avg10" | "name";
+
+// Quick-stats shown in the spotlight (first 3 present, in this order).
+const QUICK_CANDIDATES: LogStatsName[] = [
+  LogStatsName.Winrate,
+  LogStatsName.KDA,
+  LogStatsName.HeroDamageDealt,
+  LogStatsName.Eliminations
+];
+
+const QUICK_LABELS: Partial<Record<LogStatsName, string>> = {
+  [LogStatsName.Winrate]: "Winrate",
+  [LogStatsName.KDA]: "KDA",
+  [LogStatsName.HeroDamageDealt]: "Dmg/10",
+  [LogStatsName.Eliminations]: "Elims/10"
+};
 
 const RADAR_STATS: LogStatsName[] = [
   LogStatsName.HeroDamageDealt,
@@ -83,6 +101,9 @@ const HeroesView = ({ heroes, filterSlot }: Props) => {
 
   const [selectedId, setSelectedId] = useState<number>(enriched[0]?.hero.hero.id ?? 0);
   const [search, setSearch] = useState("");
+  const [insightsMode, setInsightsMode] = useState<"highlights" | "all">("highlights");
+  const [statSort, setStatSort] = useState<StatSortKey>("delta");
+  const [statSearch, setStatSearch] = useState("");
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -132,6 +153,63 @@ const HeroesView = ({ heroes, filterSlot }: Props) => {
       .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))
       .slice(0, 8);
   }, [selected]);
+
+  // Spotlight quick-stats (Winrate / KDA / Dmg10 …) with delta vs global.
+  const quickStats = useMemo(() => {
+    if (!selected) return [];
+    const out: { name: LogStatsName; label: string; value: string; delta: number | null }[] = [];
+    for (const name of QUICK_CANDIDATES) {
+      const stat = selected.hero.stats.find((s) => s.name === name);
+      if (!stat || !Number.isFinite(stat.avg_10)) continue;
+      const reversed = isRevertedStat(name);
+      const delta = computeDelta(stat.avg_10, stat.avg_10_all, reversed);
+      const value =
+        name === LogStatsName.Winrate
+          ? stat.avg_10 <= 1
+            ? formatPercent(stat.avg_10, 0)
+            : `${stat.avg_10.toFixed(0)}%`
+          : formatStatValue(name, stat.avg_10);
+      out.push({ name, label: QUICK_LABELS[name] ?? getHumanizedStats(name), value, delta });
+      if (out.length === 3) break;
+    }
+    return out;
+  }, [selected]);
+
+  // Full per-stat comparison table (All stats mode).
+  const allStatsRows = useMemo(() => {
+    if (!selected) return [];
+    const q = statSearch.trim().toLowerCase();
+    let rows = selected.hero.stats
+      .filter((s) => s.name !== LogStatsName.HeroTimePlayed)
+      .map((s) => {
+        const reversed = isRevertedStat(s.name);
+        const delta = computeDelta(s.avg_10, s.avg_10_all, reversed);
+        const isRecord =
+          s.best_all != null &&
+          Number.isFinite(s.best?.value) &&
+          Number.isFinite(s.best_all.value) &&
+          s.best.value === s.best_all.value;
+        return {
+          name: s.name,
+          label: getHumanizedStats(s.name),
+          overall: s.overall,
+          bestYou: s.best?.value,
+          avg10: s.avg_10,
+          delta,
+          bestAll: s.best_all?.value ?? null,
+          global10: s.avg_10_all,
+          isRecord
+        };
+      });
+    if (q) rows = rows.filter((r) => r.label.toLowerCase().includes(q));
+    rows.sort((a, b) => {
+      if (statSort === "name") return a.label.localeCompare(b.label);
+      if (statSort === "overall") return (b.overall ?? 0) - (a.overall ?? 0);
+      if (statSort === "avg10") return (b.avg10 ?? 0) - (a.avg10 ?? 0);
+      return Math.abs(b.delta ?? 0) - Math.abs(a.delta ?? 0);
+    });
+    return rows;
+  }, [selected, statSearch, statSort]);
 
   const mostEffective = useMemo(() => {
     let best: typeof enriched[0] | null = null;
@@ -345,8 +423,12 @@ const HeroesView = ({ heroes, filterSlot }: Props) => {
                 </span>
               </div>
             </div>
-            <div className="relative z-[1] flex gap-4.5">
-              <SpotStat label="Playtime share" value={`${(selected.share * 100).toFixed(0)}%`} />
+            <div className="relative z-[1] flex flex-wrap justify-end gap-4">
+              {quickStats.length > 0 ? (
+                quickStats.map((qs) => <QuickStat key={qs.name} label={qs.label} value={qs.value} delta={qs.delta} />)
+              ) : (
+                <QuickStat label="Playtime share" value={`${(selected.share * 100).toFixed(0)}%`} delta={null} />
+              )}
             </div>
           </div>
 
@@ -355,7 +437,29 @@ const HeroesView = ({ heroes, filterSlot }: Props) => {
             title="Insights"
             icon={<span>◐</span>}
             subtitle={`${selected.hero.hero.name} · vs global avg/10`}
+            action={
+              <div className="aqt-filters !mb-0">
+                <span
+                  className={cn("aqt-filter-chip", insightsMode === "highlights" && "active")}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setInsightsMode("highlights")}
+                >
+                  Highlights
+                </span>
+                <span
+                  className={cn("aqt-filter-chip", insightsMode === "all" && "active")}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setInsightsMode("all")}
+                >
+                  All stats
+                  <span className="aqt-count">{allStatsRows.length}</span>
+                </span>
+              </div>
+            }
           >
+            {insightsMode === "highlights" ? (
             <div className="grid grid-cols-1 gap-4 lg:grid-cols-[280px_1fr]">
               <div className="flex flex-col items-center gap-2">
                 {radarData ? (
@@ -424,6 +528,15 @@ const HeroesView = ({ heroes, filterSlot }: Props) => {
                 ) : null}
               </div>
             </div>
+            ) : (
+              <AllStatsTable
+                rows={allStatsRows}
+                sort={statSort}
+                onSortChange={setStatSort}
+                search={statSearch}
+                onSearchChange={setStatSearch}
+              />
+            )}
           </CardSurface>
         </div>
       </div>
@@ -431,11 +544,123 @@ const HeroesView = ({ heroes, filterSlot }: Props) => {
   );
 };
 
-const SpotStat = ({ label, value }: { label: string; value: string }) => (
+const QuickStat = ({ label, value, delta }: { label: string; value: string; delta: number | null }) => (
   <div className="flex flex-col items-end gap-0.5">
     <span className="text-[9.5px] font-bold uppercase tracking-[0.14em] text-[color:var(--aqt-fg-faint)]">{label}</span>
-    <span className="aqt-display text-[30px] font-bold leading-none">{value}</span>
+    <span className="aqt-display text-[28px] font-bold leading-none">{value}</span>
+    {delta != null ? (
+      <span
+        className="aqt-mono text-[10.5px] font-bold"
+        style={{ color: delta >= 0 ? "var(--aqt-emerald)" : "var(--aqt-rose)" }}
+      >
+        {formatDelta(delta)}
+      </span>
+    ) : null}
   </div>
 );
+
+interface AllStatsRow {
+  name: LogStatsName;
+  label: string;
+  overall: number;
+  bestYou: number | undefined;
+  avg10: number;
+  delta: number | null;
+  bestAll: number | null;
+  global10: number;
+  isRecord: boolean;
+}
+
+const AllStatsTable = ({
+  rows,
+  sort,
+  onSortChange,
+  search,
+  onSearchChange
+}: {
+  rows: AllStatsRow[];
+  sort: StatSortKey;
+  onSortChange: (key: StatSortKey) => void;
+  search: string;
+  onSearchChange: (value: string) => void;
+}) => {
+  // Plain render helper (not a component) to avoid recreating a component during render.
+  const sortTh = (label: string, k: StatSortKey, align: "left" | "right" = "right") => (
+    <th
+      onClick={() => onSortChange(k)}
+      className={cn(
+        "aqt-mono cursor-pointer select-none border-b border-[color:var(--aqt-border)] px-3 py-2.5 text-[10px] font-bold uppercase tracking-[0.1em]",
+        align === "right" ? "text-right" : "text-left",
+        sort === k ? "text-[color:var(--aqt-teal)]" : "text-[color:var(--aqt-fg-faint)] hover:text-[color:var(--aqt-fg-muted)]"
+      )}
+    >
+      {label}
+      {sort === k ? " ↓" : ""}
+    </th>
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="relative min-w-[180px] max-w-[280px] flex-1">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[color:var(--aqt-fg-faint)]">
+            <circle cx="11" cy="11" r="7" />
+            <path d="m20 20-3.5-3.5" />
+          </svg>
+          <input
+            placeholder="Search stats…"
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            className="w-full rounded-lg border border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.025)] px-3 py-1.5 pl-8 text-[12.5px] text-[color:var(--aqt-fg)] outline-none"
+          />
+        </div>
+        <span className="aqt-mono text-[10.5px] text-[color:var(--aqt-fg-faint)]">♔ = holds the all-players record</span>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="aqt-tnum w-full border-collapse text-[12.5px]">
+          <thead>
+            <tr>
+              {sortTh("Stat", "name", "left")}
+              {sortTh("Overall", "overall")}
+              <th className="aqt-mono border-b border-[color:var(--aqt-border)] px-3 py-2.5 text-right text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--aqt-fg-faint)]">Best (you)</th>
+              {sortTh("Avg /10", "avg10")}
+              {sortTh("Δ", "delta")}
+              <th className="aqt-mono border-b border-[color:var(--aqt-border)] px-3 py-2.5 text-right text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--aqt-fg-faint)]">Best (all)</th>
+              <th className="aqt-mono border-b border-[color:var(--aqt-border)] px-3 py-2.5 text-right text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--aqt-fg-faint)]">Global /10</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.name} className="border-b border-[color:var(--aqt-border)] last:border-b-0 hover:bg-[hsl(0_0%_100%/0.02)]">
+                <td className="px-3 py-2 text-left font-medium text-[color:var(--aqt-fg)]">
+                  {r.label}
+                  {r.isRecord ? <span className="ml-1.5 text-[color:var(--aqt-amber)]" title="Holds the all-players record">♔</span> : null}
+                </td>
+                <td className="aqt-mono px-3 py-2 text-right text-[color:var(--aqt-fg-muted)]">{formatStatValue(r.name, r.overall)}</td>
+                <td className="aqt-mono px-3 py-2 text-right text-[color:var(--aqt-fg-muted)]">
+                  {r.bestYou != null ? formatStatValue(r.name, r.bestYou) : "—"}
+                </td>
+                <td className="aqt-mono px-3 py-2 text-right font-semibold text-[color:var(--aqt-fg)]">{formatStatValue(r.name, r.avg10)}</td>
+                <td
+                  className="aqt-mono px-3 py-2 text-right font-bold"
+                  style={{ color: r.delta == null ? "var(--aqt-fg-faint)" : r.delta >= 0 ? "var(--aqt-emerald)" : "var(--aqt-rose)" }}
+                >
+                  {r.delta != null ? formatDelta(r.delta) : "—"}
+                </td>
+                <td className="aqt-mono px-3 py-2 text-right text-[color:var(--aqt-fg-dim)]">
+                  {r.bestAll != null ? formatStatValue(r.name, r.bestAll) : "—"}
+                </td>
+                <td className="aqt-mono px-3 py-2 text-right text-[color:var(--aqt-fg-dim)]">{formatStatValue(r.name, r.global10)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {rows.length === 0 ? (
+          <div className="py-8 text-center text-[12px] text-[color:var(--aqt-fg-dim)]">No stats match search</div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
 
 export default HeroesView;

--- a/frontend/src/app/(site)/users/components/redesign/MapsView.tsx
+++ b/frontend/src/app/(site)/users/components/redesign/MapsView.tsx
@@ -1,16 +1,21 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useDebounce } from "use-debounce";
 import { cn } from "@/lib/utils";
 
 import Image from "next/image";
 import userService from "@/services/user.service";
-import { UserMapRead, UserMapsSummary } from "@/types/user.types";
+import { UserMapHeroStats, UserMapsSummary } from "@/types/user.types";
 import { CardSurface } from "@/app/(site)/users/components/redesign/atoms";
-import HeroImage, { HeroStrip } from "@/components/hero/HeroImage";
+import SearchableImageSelect, {
+  type SearchableImageOption
+} from "@/app/(site)/users/compare/components/SearchableImageSelect";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Progress } from "@/components/ui/progress";
 import { getWinrateColor } from "@/utils/colors";
+import { formatPercent, formatSeconds } from "@/app/(site)/users/components/user-maps-explorer/utils";
 
 interface Props {
   userId: number;
@@ -18,40 +23,243 @@ interface Props {
 
 const MODE_ORDER = ["Control", "Escort", "Hybrid", "Flashpoint", "Push", "Assault"] as const;
 
+type SortKey = "winrate" | "count" | "name";
+type OrderKey = "asc" | "desc";
+
+const MIN_COUNT_OPTIONS = [1, 3, 5, 10];
+const PER_PAGE_OPTIONS = [15, 30, -1];
+const SORT_OPTIONS: { value: SortKey; label: string }[] = [
+  { value: "winrate", label: "Winrate" },
+  { value: "count", label: "Games" },
+  { value: "name", label: "Name" }
+];
+
+// ─── Per-hero popover (winrate / games / record / playtime share on the map) ─────
+
+const HeroStatsChip = ({
+  heroStats,
+  open,
+  onRequestOpen,
+  onRequestClose
+}: {
+  heroStats: UserMapHeroStats;
+  open: boolean;
+  onRequestOpen: () => void;
+  onRequestClose: () => void;
+}) => {
+  const closeTimeoutRef = useRef<number | null>(null);
+  const winrateColor = getWinrateColor(heroStats.win_rate);
+  const shareValue = Math.max(0, Math.min(100, heroStats.playtime_share_on_map * 100));
+
+  const clearCloseTimeout = () => {
+    if (closeTimeoutRef.current === null) return;
+    window.clearTimeout(closeTimeoutRef.current);
+    closeTimeoutRef.current = null;
+  };
+
+  const scheduleClose = (delayMs = 120) => {
+    clearCloseTimeout();
+    closeTimeoutRef.current = window.setTimeout(() => onRequestClose(), delayMs);
+  };
+
+  useEffect(() => {
+    return () => clearCloseTimeout();
+  }, []);
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => (nextOpen ? onRequestOpen() : onRequestClose())}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="relative h-7 w-7 overflow-hidden rounded-md transition-transform hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--aqt-teal)]"
+          aria-label={`${heroStats.hero.name} on this map`}
+          onPointerEnter={(e) => {
+            if (e.pointerType !== "mouse") return;
+            clearCloseTimeout();
+          }}
+          onPointerMove={(e) => {
+            if (e.pointerType !== "mouse") return;
+            clearCloseTimeout();
+            if (!open) onRequestOpen();
+          }}
+          onPointerLeave={(e) => {
+            if (e.pointerType !== "mouse") return;
+            scheduleClose();
+          }}
+          onFocus={() => {
+            clearCloseTimeout();
+            if (!open) onRequestOpen();
+          }}
+          onBlur={() => scheduleClose(0)}
+        >
+          <Image
+            src={heroStats.hero.image_path}
+            alt={heroStats.hero.name}
+            fill
+            sizes="28px"
+            className="object-cover select-none"
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-80 data-[state=open]:animate-none data-[state=closed]:animate-none"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onPointerEnter={(e) => {
+          if (e.pointerType !== "mouse") return;
+          clearCloseTimeout();
+        }}
+        onPointerLeave={(e) => {
+          if (e.pointerType !== "mouse") return;
+          scheduleClose();
+        }}
+      >
+        <div className="flex items-start gap-3">
+          <div className="h-12 w-12 shrink-0">
+            <Image
+              src={heroStats.hero.image_path}
+              alt={heroStats.hero.name}
+              width={48}
+              height={48}
+              className="h-full w-full object-contain select-none"
+            />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-semibold">{heroStats.hero.name}</div>
+            <div className="mt-1 grid grid-cols-3 gap-2 text-xs">
+              <div className="rounded-md border border-border/50 bg-muted/10 px-2 py-1">
+                <div className="text-muted-foreground">Winrate</div>
+                <div className="font-semibold tabular-nums" style={{ color: winrateColor }}>
+                  {formatPercent(heroStats.win_rate, 0)}
+                </div>
+              </div>
+              <div className="rounded-md border border-border/50 bg-muted/10 px-2 py-1">
+                <div className="text-muted-foreground">Games</div>
+                <div className="font-semibold tabular-nums">{heroStats.games}</div>
+              </div>
+              <div className="rounded-md border border-border/50 bg-muted/10 px-2 py-1">
+                <div className="text-muted-foreground">Record</div>
+                <div className="font-semibold tabular-nums">
+                  {heroStats.win}-{heroStats.loss}-{heroStats.draw}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>Playtime on this map</span>
+            <span className="tabular-nums">
+              {formatSeconds(heroStats.playtime_seconds)} | {shareValue.toFixed(0)}%
+            </span>
+          </div>
+          <div className="mt-2">
+            <Progress value={shareValue} aria-label="Playtime share on this map" />
+          </div>
+          <div className="mt-2 text-[11px] text-muted-foreground">
+            Games counted when hero time played is &gt; 60s.
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+const AqtSelect = ({
+  value,
+  onChange,
+  options,
+  title
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  options: { value: string; label: string }[];
+  title?: string;
+}) => (
+  <select
+    value={value}
+    onChange={(e) => onChange(e.target.value)}
+    title={title}
+    className="aqt-mono cursor-pointer rounded-lg border border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.02)] px-2.5 py-1.5 text-[12px] text-[color:var(--aqt-fg)] outline-none"
+  >
+    {options.map((o) => (
+      <option key={o.value} value={o.value} className="bg-[#10151c] text-[color:var(--aqt-fg)]">
+        {o.label}
+      </option>
+    ))}
+  </select>
+);
+
 const MapsView = ({ userId }: Props) => {
   const [modeFilter, setModeFilter] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [debouncedSearch] = useDebounce(search, 300);
-  const [sort] = useState<"winrate" | "count" | "name">("winrate");
-  const [order] = useState<"asc" | "desc">("desc");
+  const [sort, setSort] = useState<SortKey>("winrate");
+  const [order, setOrder] = useState<OrderKey>("desc");
   const [minCount, setMinCount] = useState(1);
+  const [perPage, setPerPage] = useState(15);
+  const [page, setPage] = useState(1);
+  const [tournamentId, setTournamentId] = useState<number | undefined>(undefined);
+  const [activeHeroPopoverKey, setActiveHeroPopoverKey] = useState<string | null>(null);
+
+  // Reset to first page whenever any filter/sort that changes the result set moves.
+  // Render-time adjustment (React-recommended) instead of an effect with setState.
+  const filterKey = `${modeFilter}|${sort}|${order}|${minCount}|${perPage}|${tournamentId}|${debouncedSearch}`;
+  const [prevFilterKey, setPrevFilterKey] = useState(filterKey);
+  if (filterKey !== prevFilterKey) {
+    setPrevFilterKey(filterKey);
+    setPage(1);
+  }
+
+  const tournamentsQuery = useQuery({
+    queryKey: ["user-tournaments", userId],
+    queryFn: () => userService.getUserTournaments(userId),
+    staleTime: 5 * 60 * 1000
+  });
+
+  const tournamentOptions = useMemo<SearchableImageOption[]>(
+    () => (tournamentsQuery.data ?? []).map((t) => ({ value: String(t.id), label: t.name })),
+    [tournamentsQuery.data]
+  );
 
   const mapsQuery = useQuery({
-    queryKey: ["user-maps-redesign", userId, debouncedSearch, minCount],
+    queryKey: ["user-maps-redesign", userId, debouncedSearch, minCount, tournamentId],
     queryFn: () =>
       userService.getUserMaps(userId, {
         page: 1,
         perPage: -1,
-        sort,
-        order,
+        sort: "winrate",
+        order: "desc",
         query: debouncedSearch.trim(),
-        minCount
+        minCount,
+        tournamentId
       }),
     staleTime: 60_000
   });
 
   const summaryQuery = useQuery({
-    queryKey: ["user-maps-summary-redesign", userId, debouncedSearch, minCount],
-    queryFn: () => userService.getUserMapsSummary(userId, { query: debouncedSearch.trim(), minCount }),
+    queryKey: ["user-maps-summary-redesign", userId, debouncedSearch, minCount, tournamentId],
+    queryFn: () =>
+      userService.getUserMapsSummary(userId, {
+        query: debouncedSearch.trim(),
+        minCount,
+        tournamentId
+      }),
     staleTime: 60_000
   });
 
   const summary = summaryQuery.data as UserMapsSummary | undefined;
   const allMaps = mapsQuery.data?.results ?? [];
 
-  // Aggregate by gamemode
+  // Aggregate by gamemode (over the full, tournament-scoped set).
   const modeStats = useMemo(() => {
-    const buckets = new Map<string, { mode: string; maps: Set<number>; games: number; win: number; loss: number; draw: number }>();
+    const buckets = new Map<
+      string,
+      { mode: string; maps: Set<number>; games: number; win: number; loss: number; draw: number }
+    >();
     allMaps.forEach((row) => {
       const mode = row.map.gamemode?.name ?? "Unknown";
       const b = buckets.get(mode) ?? { mode, maps: new Set<number>(), games: 0, win: 0, loss: 0, draw: 0 };
@@ -69,14 +277,22 @@ const MapsView = ({ userId }: Props) => {
     });
   }, [allMaps]);
 
-  const filteredMaps = useMemo(() => {
+  const sortedMaps = useMemo(() => {
     let rows = [...allMaps];
-    if (modeFilter) {
-      rows = rows.filter((r) => r.map.gamemode?.name === modeFilter);
-    }
-    rows.sort((a, b) => b.win_rate - a.win_rate);
+    if (modeFilter) rows = rows.filter((r) => r.map.gamemode?.name === modeFilter);
+    rows.sort((a, b) => {
+      let cmp = 0;
+      if (sort === "winrate") cmp = a.win_rate - b.win_rate;
+      else if (sort === "count") cmp = a.count - b.count;
+      else cmp = a.map.name.localeCompare(b.map.name);
+      return order === "asc" ? cmp : -cmp;
+    });
     return rows;
-  }, [allMaps, modeFilter]);
+  }, [allMaps, modeFilter, sort, order]);
+
+  const totalCount = sortedMaps.length;
+  const pages = perPage === -1 ? 1 : Math.max(1, Math.ceil(totalCount / perPage));
+  const pageMaps = perPage === -1 ? sortedMaps : sortedMaps.slice((page - 1) * perPage, page * perPage);
 
   const modeClass = (mode: string) => {
     const lower = mode.toLowerCase();
@@ -155,7 +371,7 @@ const MapsView = ({ userId }: Props) => {
         </div>
       </CardSurface>
 
-      {/* Filter chips */}
+      {/* Filter chips + controls */}
       <div className="aqt-filters">
         <span
           className={cn("aqt-filter-chip", modeFilter === null && "active")}
@@ -177,15 +393,47 @@ const MapsView = ({ userId }: Props) => {
           </span>
         ))}
         <span className="aqt-filter-divider" />
-        <span
-          className={cn("aqt-filter-chip", minCount === 3 && "active")}
-          onClick={() => setMinCount(minCount === 3 ? 1 : 3)}
-          role="button"
-          tabIndex={0}
+
+        <div className="w-48">
+          <SearchableImageSelect
+            value={tournamentId ? String(tournamentId) : undefined}
+            onValueChange={(val) => setTournamentId(val ? Number(val) : undefined)}
+            options={tournamentOptions}
+            placeholder="All tournaments"
+            searchPlaceholder="Search tournament…"
+            isLoading={tournamentsQuery.isLoading}
+            disabled={tournamentsQuery.isLoading || tournamentsQuery.isError}
+          />
+        </div>
+
+        <AqtSelect
+          title="Minimum games"
+          value={String(minCount)}
+          onChange={(v) => setMinCount(Number(v))}
+          options={MIN_COUNT_OPTIONS.map((n) => ({ value: String(n), label: `Min ${n} games` }))}
+        />
+        <AqtSelect
+          title="Rows per page"
+          value={String(perPage)}
+          onChange={(v) => setPerPage(Number(v))}
+          options={PER_PAGE_OPTIONS.map((n) => ({ value: String(n), label: n === -1 ? "Rows: All" : `Rows: ${n}` }))}
+        />
+        <AqtSelect
+          title="Sort by"
+          value={sort}
+          onChange={(v) => setSort(v as SortKey)}
+          options={SORT_OPTIONS.map((o) => ({ value: o.value, label: `Sort: ${o.label}` }))}
+        />
+        <button
+          type="button"
+          onClick={() => setOrder((o) => (o === "asc" ? "desc" : "asc"))}
+          title={order === "asc" ? "Ascending" : "Descending"}
+          className="aqt-mono inline-flex h-8 w-8 items-center justify-center rounded-lg border border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.02)] text-[13px] text-[color:var(--aqt-fg-muted)] transition-colors hover:text-[color:var(--aqt-fg)]"
         >
-          Min 3 games
-        </span>
-        <div className="filter-search relative ml-auto min-w-[200px] max-w-[300px] flex-1">
+          {order === "asc" ? "↑" : "↓"}
+        </button>
+
+        <div className="filter-search relative ml-auto min-w-[180px] max-w-[300px] flex-1">
           <input
             placeholder="Search maps…"
             value={search}
@@ -201,7 +449,7 @@ const MapsView = ({ userId }: Props) => {
 
       {/* Map rows */}
       <CardSurface flush>
-        <div className="border-b border-[color:var(--aqt-border)] px-[18px] py-3 grid grid-cols-[64px_1fr_1fr_80px_60px_50px] gap-3.5 items-center text-[10px] font-bold uppercase tracking-[0.14em] text-[color:var(--aqt-fg-faint)]">
+        <div className="grid grid-cols-[64px_1fr_1fr_minmax(0,1.2fr)_60px_50px] items-center gap-3.5 border-b border-[color:var(--aqt-border)] px-[18px] py-3 text-[10px] font-bold uppercase tracking-[0.14em] text-[color:var(--aqt-fg-faint)]">
           <div />
           <div>Map</div>
           <div>Winrate</div>
@@ -209,20 +457,15 @@ const MapsView = ({ userId }: Props) => {
           <div className="text-right">Record</div>
           <div className="text-right">Games</div>
         </div>
-        {filteredMaps.map((row) => {
+        {pageMaps.map((row) => {
           const wr = row.win_rate * 100;
           const wrCls = wr >= 60 ? "good" : wr <= 40 ? "bad" : "";
+          const heroStats = row.hero_stats ?? [];
           return (
-            <div key={row.map.id} className="aqt-map-row">
+            <div key={row.map.id} className="aqt-map-row" style={{ gridTemplateColumns: "64px 1fr 1fr minmax(0,1.2fr) 60px 50px" }}>
               <div className="aqt-map-thumb">
                 {row.map.image_path ? (
-                  <Image
-                    src={row.map.image_path}
-                    alt={row.map.name}
-                    fill
-                    sizes="56px"
-                    className="object-cover"
-                  />
+                  <Image src={row.map.image_path} alt={row.map.name} fill sizes="56px" className="object-cover" />
                 ) : (
                   <span>{row.map.name.split(/\s+/).map((w) => w[0]).slice(0, 2).join("").toUpperCase()}</span>
                 )}
@@ -239,10 +482,26 @@ const MapsView = ({ userId }: Props) => {
                 </div>
                 <span className={cn("aqt-num", wrCls)}>{wr.toFixed(0)}%</span>
               </div>
-              <HeroStrip
-                heroes={(row.hero_stats ?? row.heroes ?? []).slice(0, 4).map((h) => h.hero)}
-                size="sm"
-              />
+              <div className="flex flex-wrap items-center gap-1">
+                {heroStats.length > 0 ? (
+                  heroStats.slice(0, 8).map((hs) => {
+                    const key = `${row.map.id}:${hs.hero.id}`;
+                    return (
+                      <HeroStatsChip
+                        key={key}
+                        heroStats={hs}
+                        open={activeHeroPopoverKey === key}
+                        onRequestOpen={() => setActiveHeroPopoverKey(key)}
+                        onRequestClose={() =>
+                          setActiveHeroPopoverKey((cur) => (cur === key ? null : cur))
+                        }
+                      />
+                    );
+                  })
+                ) : (
+                  <span className="aqt-mono text-[11px] text-[color:var(--aqt-fg-faint)]">—</span>
+                )}
+              </div>
               <span className="aqt-mono text-right text-[12.5px] font-semibold text-[color:var(--aqt-fg-muted)]">
                 {row.win}-{row.loss}-{row.draw}
               </span>
@@ -250,15 +509,63 @@ const MapsView = ({ userId }: Props) => {
             </div>
           );
         })}
-        {filteredMaps.length === 0 ? (
+        {pageMaps.length === 0 ? (
           <div className="py-10 text-center text-[color:var(--aqt-fg-dim)]">
             {mapsQuery.isLoading ? "Loading…" : "No maps match the filters"}
+          </div>
+        ) : null}
+
+        {/* Pagination footer */}
+        {perPage !== -1 && totalCount > 0 ? (
+          <div className="flex items-center justify-between border-t border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.012)] px-[18px] py-3.5">
+            <span className="aqt-mono text-[12px] text-[color:var(--aqt-fg-dim)]">
+              Showing {(page - 1) * perPage + 1}–{Math.min(page * perPage, totalCount)} of {totalCount}
+            </span>
+            <div className="flex gap-1">
+              <PageBtn disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>‹</PageBtn>
+              {Array.from({ length: Math.min(3, pages) }, (_, i) => i + 1).map((n) => (
+                <PageBtn key={n} active={n === page} onClick={() => setPage(n)}>{n}</PageBtn>
+              ))}
+              {pages > 3 ? (
+                <>
+                  {page > 4 ? <span className="aqt-mono px-2 text-[color:var(--aqt-fg-faint)]">…</span> : null}
+                  <PageBtn active={page === pages} onClick={() => setPage(pages)}>{pages}</PageBtn>
+                </>
+              ) : null}
+              <PageBtn disabled={page >= pages} onClick={() => setPage((p) => Math.min(pages, p + 1))}>›</PageBtn>
+            </div>
           </div>
         ) : null}
       </CardSurface>
     </div>
   );
 };
+
+const PageBtn = ({
+  active,
+  disabled,
+  onClick,
+  children
+}: {
+  active?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+}) => (
+  <button
+    onClick={onClick}
+    disabled={disabled}
+    className={cn(
+      "aqt-mono inline-flex h-8 min-w-[32px] items-center justify-center rounded-[6px] border px-2 text-[12px] transition-colors",
+      active
+        ? "border-[hsl(174_72%_46%/0.3)] bg-[hsl(174_72%_46%/0.12)] text-[color:var(--aqt-teal)]"
+        : "border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.02)] text-[color:var(--aqt-fg-muted)] hover:text-[color:var(--aqt-fg)]",
+      disabled && "cursor-not-allowed opacity-40"
+    )}
+  >
+    {children}
+  </button>
+);
 
 const KPI = ({ label, value, unit, color, sub }: { label: string; value: string; unit?: string; color?: string; sub?: string }) => (
   <CardSurface>

--- a/frontend/src/app/(site)/users/components/redesign/MatchLogIndicator.tsx
+++ b/frontend/src/app/(site)/users/components/redesign/MatchLogIndicator.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import React from "react";
+import { ScrollText, FileDown, FileX } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface MatchLogIndicatorProps {
+  hasLogs: boolean;
+  /**
+   * Download URL for the log file. When provided (and `hasLogs`), the indicator
+   * becomes an actionable download link. Backend endpoint is pending
+   * (see profile restore plan, Phase 7) — until it exists callers omit this and
+   * the badge stays informational.
+   */
+  downloadUrl?: string | null;
+  /** Alternative to `downloadUrl`: custom click handler that performs the download. */
+  onDownload?: () => void;
+  /** Log file name, used for the `download` attribute and aria/title labels. */
+  logName?: string | null;
+  size?: number;
+  className?: string;
+}
+
+const emeraldStyle: React.CSSProperties = {
+  borderColor: "hsl(152 60% 50% / 0.3)",
+  color: "var(--aqt-emerald)",
+  background: "hsl(152 60% 50% / 0.08)"
+};
+
+const mutedStyle: React.CSSProperties = {
+  borderColor: "var(--aqt-border)",
+  color: "var(--aqt-fg-faint)",
+  background: "transparent"
+};
+
+const BASE =
+  "inline-flex h-7 w-7 items-center justify-center rounded-[7px] border transition-colors";
+
+/**
+ * Reusable indicator for match-log availability.
+ * - no logs → dimmed, non-interactive;
+ * - logs without download wiring → emerald icon, tooltip "Logs available";
+ * - logs + download → actionable download button/link.
+ */
+const MatchLogIndicator = ({
+  hasLogs,
+  downloadUrl,
+  onDownload,
+  logName,
+  size = 15,
+  className
+}: MatchLogIndicatorProps) => {
+  if (!hasLogs) {
+    return (
+      <span
+        className={cn(BASE, className)}
+        style={mutedStyle}
+        title="No logs"
+        aria-label="No logs available"
+      >
+        <FileX size={size} strokeWidth={1.75} />
+      </span>
+    );
+  }
+
+  const canDownload = Boolean(downloadUrl || onDownload);
+
+  if (!canDownload) {
+    return (
+      <span
+        className={cn(BASE, className)}
+        style={emeraldStyle}
+        title="Logs available"
+        aria-label="Logs available"
+      >
+        <ScrollText size={size} strokeWidth={1.75} />
+      </span>
+    );
+  }
+
+  const label = logName ? `Download log: ${logName}` : "Download log";
+
+  if (downloadUrl) {
+    return (
+      <a
+        href={downloadUrl}
+        download={logName ?? undefined}
+        onClick={(e) => e.stopPropagation()}
+        className={cn(BASE, "hover:brightness-125", className)}
+        style={emeraldStyle}
+        title={label}
+        aria-label={label}
+      >
+        <FileDown size={size} strokeWidth={1.9} />
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onDownload?.();
+      }}
+      className={cn(BASE, "hover:brightness-125", className)}
+      style={emeraldStyle}
+      title={label}
+      aria-label={label}
+    >
+      <FileDown size={size} strokeWidth={1.9} />
+    </button>
+  );
+};
+
+export default MatchLogIndicator;

--- a/frontend/src/app/(site)/users/components/redesign/MatchesTable.tsx
+++ b/frontend/src/app/(site)/users/components/redesign/MatchesTable.tsx
@@ -7,10 +7,14 @@ import { cn } from "@/lib/utils";
 import { EncounterWithUserStats } from "@/types/user.types";
 import {
   CardSurface,
+  MvpPill,
   ResTag,
   ScoreCell,
-  StagePill
+  StagePill,
+  mvpRank,
+  ordinal
 } from "@/app/(site)/users/components/redesign/atoms";
+import MatchLogIndicator from "@/app/(site)/users/components/redesign/MatchLogIndicator";
 import { HeroStrip } from "@/components/hero/HeroImage";
 import type { Hero } from "@/types/hero.types";
 
@@ -22,7 +26,7 @@ interface Props {
   selfUserId: number;
 }
 
-type Filter = "all" | "wins" | "losses" | "draws" | "group" | "playoffs" | "finals" | "has_logs";
+type Filter = "all" | "wins" | "losses" | "draws" | "group" | "playoffs" | "finals" | "mvp1" | "has_logs";
 
 const FILTERS: { key: Filter; label: string }[] = [
   { key: "all", label: "All" },
@@ -32,8 +36,12 @@ const FILTERS: { key: Filter; label: string }[] = [
   { key: "group", label: "Group" },
   { key: "playoffs", label: "Playoffs" },
   { key: "finals", label: "Finals" },
+  { key: "mvp1", label: "MVP 1st" },
   { key: "has_logs", label: "Has logs" }
 ];
+
+const encounterHasMvp1 = (enc: EncounterWithUserStats): boolean =>
+  (enc.matches ?? []).some((m) => m.performance === 1);
 
 const stageKindFor = (name: string | undefined): "group" | "playoffs" | "finals" | "default" => {
   if (!name) return "default";
@@ -44,10 +52,7 @@ const stageKindFor = (name: string | undefined): "group" | "playoffs" | "finals"
   return "default";
 };
 
-const stageShort = (name: string | undefined): string => {
-  if (!name) return "—";
-  return name.length > 8 ? name.slice(0, 8) : name;
-};
+const stageLabel = (name: string | undefined): string => name?.trim() || "—";
 
 const MatchesTable = ({ encounters, total, page, perPage, selfUserId }: Props) => {
   const router = useRouter();
@@ -75,6 +80,7 @@ const MatchesTable = ({ encounters, total, page, perPage, selfUserId }: Props) =
       if (filter === "group" && stageKind !== "group") return false;
       if (filter === "playoffs" && stageKind !== "playoffs") return false;
       if (filter === "finals" && stageKind !== "finals") return false;
+      if (filter === "mvp1" && !encounterHasMvp1(enc)) return false;
       if (filter === "has_logs" && !enc.has_logs) return false;
 
       return true;
@@ -91,6 +97,7 @@ const MatchesTable = ({ encounters, total, page, perPage, selfUserId }: Props) =
   }).length;
   const drawCount = encounters.length - winCount - lossCount;
   const logsCount = encounters.filter((e) => e.has_logs).length;
+  const mvp1Count = encounters.filter(encounterHasMvp1).length;
 
   const pages = Math.max(1, Math.ceil(total / perPage));
 
@@ -148,6 +155,8 @@ const MatchesTable = ({ encounters, total, page, perPage, selfUserId }: Props) =
               ? lossCount
               : f.key === "draws"
               ? drawCount
+              : f.key === "mvp1"
+              ? mvp1Count
               : f.key === "has_logs"
               ? logsCount
               : null;
@@ -184,7 +193,7 @@ const MatchesTable = ({ encounters, total, page, perPage, selfUserId }: Props) =
             <table className="aqt-tnum w-full border-collapse text-[13px]">
               <thead>
                 <tr>
-                  {["Tournament", "Stage", "Match", "Score", "Heroes", "Logs"].map((h) => (
+                  {["Tournament", "Stage", "Match", "Score", "Heroes", "MVP", "Close.", "Logs"].map((h) => (
                     <th
                       key={h}
                       className="aqt-mono border-b border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.015)] px-3.5 py-3 text-left text-[10px] font-bold uppercase tracking-[0.14em] text-[color:var(--aqt-fg-faint)]"
@@ -218,11 +227,18 @@ const MatchesTable = ({ encounters, total, page, perPage, selfUserId }: Props) =
                     });
                   });
 
+                  const mvpMatches = (enc.matches ?? []).filter((m) => m.performance != null);
+
                   return (
-                    <tr key={enc.id} className="border-b border-[hsl(215_20%_10%)] transition-colors last:border-b-0 hover:bg-[hsl(0_0%_100%/0.025)]">
+                    <tr
+                      key={enc.id}
+                      onClick={() => router.push(`/encounters/${enc.id}`)}
+                      className="cursor-pointer border-b border-[hsl(215_20%_10%)] transition-colors last:border-b-0 hover:bg-[hsl(0_0%_100%/0.025)]"
+                    >
                       <td className="px-3.5 py-3">
                         <Link
                           href={`/tournaments/${enc.tournament_id}`}
+                          onClick={(e) => e.stopPropagation()}
                           className="aqt-mono inline-flex items-center gap-1.5 rounded-[5px] border px-2 py-0.5 text-[10.5px] font-bold"
                           style={{
                             background: "hsl(174 72% 46% / 0.08)",
@@ -234,12 +250,16 @@ const MatchesTable = ({ encounters, total, page, perPage, selfUserId }: Props) =
                         </Link>
                       </td>
                       <td className="px-3.5 py-3">
-                        <StagePill kind={kind}>{stageShort(enc.stage_item?.name ?? enc.stage?.name)}</StagePill>
+                        <StagePill kind={kind}>{stageLabel(enc.stage_item?.name ?? enc.stage?.name)}</StagePill>
                       </td>
                       <td className="px-3.5 py-3">
                         <span className="inline-flex items-center gap-2">
                           <ResTag kind={resKind} />
-                          <Link href={`/encounters/${enc.id}`} className="hover:text-[color:var(--aqt-teal)]">
+                          <Link
+                            href={`/encounters/${enc.id}`}
+                            onClick={(e) => e.stopPropagation()}
+                            className="hover:text-[color:var(--aqt-teal)]"
+                          >
                             {userTeamName} vs {opponentName}
                           </Link>
                         </span>
@@ -250,15 +270,27 @@ const MatchesTable = ({ encounters, total, page, perPage, selfUserId }: Props) =
                       <td className="px-3.5 py-3">
                         <HeroStrip heroes={heroList} size="sm" limit={4} />
                       </td>
-                      <td className="px-3.5 py-3 text-center" style={{ color: enc.has_logs ? "var(--aqt-emerald)" : "var(--aqt-fg-faint)" }}>
-                        {enc.has_logs ? "⊕" : "—"}
+                      <td className="px-3.5 py-3">
+                        <span className="inline-flex items-center gap-1">
+                          {mvpMatches.length > 0
+                            ? mvpMatches.map((m) => (
+                                <MvpPill key={m.id} rank={mvpRank(m.performance)} label={ordinal(m.performance as number)} />
+                              ))
+                            : <span className="aqt-mono text-[color:var(--aqt-fg-faint)]">—</span>}
+                        </span>
+                      </td>
+                      <td className="aqt-mono px-3.5 py-3 text-[11px] text-[color:var(--aqt-fg-dim)]">
+                        {enc.closeness != null ? `${(enc.closeness * 100).toFixed(0)}%` : "—"}
+                      </td>
+                      <td className="px-3.5 py-3" onClick={(e) => e.stopPropagation()}>
+                        <MatchLogIndicator hasLogs={enc.has_logs} />
                       </td>
                     </tr>
                   );
                 })}
                 {filtered.length === 0 ? (
                   <tr>
-                    <td colSpan={6} className="px-3.5 py-10 text-center text-[color:var(--aqt-fg-dim)]">
+                    <td colSpan={8} className="px-3.5 py-10 text-center text-[color:var(--aqt-fg-dim)]">
                       No matches for current filter
                     </td>
                   </tr>

--- a/frontend/src/app/(site)/users/components/redesign/OverviewTeammatesSynergy.tsx
+++ b/frontend/src/app/(site)/users/components/redesign/OverviewTeammatesSynergy.tsx
@@ -1,5 +1,9 @@
-import React from "react";
+"use client";
+
+import React, { useMemo, useState } from "react";
+import Link from "next/link";
 import { UserBestTeammate } from "@/types/user.types";
+import { LogStatsName } from "@/types/stats.types";
 import { CardSurface, heroInitials } from "@/app/(site)/users/components/redesign/atoms";
 
 interface Props {
@@ -28,7 +32,15 @@ const POSITIONS = [
   { left: 58, top: 8 }
 ];
 
+const playerSlug = (name: string) => name.replace(/#/g, "-");
+
+const formatStat = (value: number | null | undefined, digits: number) =>
+  value != null && Number.isFinite(value) ? value.toFixed(digits) : "—";
+
 const OverviewTeammatesSynergy = ({ teammates, selfName, totalCount, totalMaps }: Props) => {
+  const [view, setView] = useState<"network" | "all">("network");
+  const [search, setSearch] = useState("");
+
   const top = teammates.slice(0, 6);
   if (top.length === 0) return null;
 
@@ -39,61 +51,173 @@ const OverviewTeammatesSynergy = ({ teammates, selfName, totalCount, totalMaps }
       flush
       title="Best teammates"
       icon={<span>⊕</span>}
-      action={<span className="aqt-seeall">{totalCount} stack-mates</span>}
+      action={
+        <button
+          type="button"
+          className="aqt-seeall"
+          onClick={() => setView((v) => (v === "network" ? "all" : "network"))}
+        >
+          {view === "network" ? "All →" : "← Network"}
+        </button>
+      }
     >
-      <div className="relative h-[280px] p-2">
-        <svg viewBox="0 0 320 260" preserveAspectRatio="none" className="absolute inset-0 h-full w-full pointer-events-none">
-          <defs>
-            <linearGradient id="syn-line" x1="0" y1="0" x2="1" y2="0">
-              <stop offset="0" stopColor="hsl(38 95% 55% / 0.5)" />
-              <stop offset="1" stopColor="hsl(174 72% 46% / 0.5)" />
-            </linearGradient>
-          </defs>
-          {top.map((tm, i) => {
-            const pos = POSITIONS[i] ?? POSITIONS[POSITIONS.length - 1];
-            const x = (pos.left / 100) * 320;
-            const y = (pos.top / 100) * 260;
-            const width = Math.max(1.5, Math.min(3, 1 + tm.tournaments * 0.7));
-            return (
-              <line
-                key={tm.user.id}
-                x1={160}
-                y1={130}
-                x2={x}
-                y2={y}
-                stroke="url(#syn-line)"
-                strokeWidth={width}
-              />
-            );
-          })}
-        </svg>
-        <SynNode left={50} top={50} initials={meInitials} name="You" isMe accent="var(--aqt-amber)" />
-        {top.map((tm, i) => {
-          const pos = POSITIONS[i] ?? POSITIONS[POSITIONS.length - 1];
-          const [tmName, tmTag] = tm.user.name.split("#");
-          return (
-            <SynNode
-              key={tm.user.id}
-              left={pos.left}
-              top={pos.top}
-              initials={heroInitials(tmName)}
-              name={tmName}
-              tag={tmTag ? `#${tmTag}` : ""}
-              sub={`×${tm.tournaments} · ${(tm.winrate * 100).toFixed(0)}% WR`}
-              avBg={TEAMMATE_COLORS[i % TEAMMATE_COLORS.length]}
-            />
-          );
-        })}
-      </div>
-      <div
-        className="aqt-mono flex justify-between border-t border-[color:var(--aqt-border)] px-[18px] py-2.5 text-[11px] text-[color:var(--aqt-fg-dim)]"
-      >
-        <span>Edges sized by appearances</span>
-        <span>{totalCount} unique · {totalMaps} maps</span>
-      </div>
+      {view === "network" ? (
+        <NetworkView top={top} meInitials={meInitials} totalCount={totalCount} totalMaps={totalMaps} />
+      ) : (
+        <AllTeammatesTable teammates={teammates} search={search} onSearchChange={setSearch} />
+      )}
     </CardSurface>
   );
 };
+
+const NetworkView = ({
+  top,
+  meInitials,
+  totalCount,
+  totalMaps
+}: {
+  top: UserBestTeammate[];
+  meInitials: string;
+  totalCount: number;
+  totalMaps: number;
+}) => (
+  <>
+    <div className="relative h-[280px] p-2">
+      <svg viewBox="0 0 320 260" preserveAspectRatio="none" className="absolute inset-0 h-full w-full pointer-events-none">
+        <defs>
+          <linearGradient id="syn-line" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0" stopColor="hsl(38 95% 55% / 0.5)" />
+            <stop offset="1" stopColor="hsl(174 72% 46% / 0.5)" />
+          </linearGradient>
+        </defs>
+        {top.map((tm, i) => {
+          const pos = POSITIONS[i] ?? POSITIONS[POSITIONS.length - 1];
+          const x = (pos.left / 100) * 320;
+          const y = (pos.top / 100) * 260;
+          const width = Math.max(1.5, Math.min(3, 1 + tm.tournaments * 0.7));
+          return <line key={tm.user.id} x1={160} y1={130} x2={x} y2={y} stroke="url(#syn-line)" strokeWidth={width} />;
+        })}
+      </svg>
+      <SynNode left={50} top={50} initials={meInitials} name="You" isMe accent="var(--aqt-amber)" />
+      {top.map((tm, i) => {
+        const pos = POSITIONS[i] ?? POSITIONS[POSITIONS.length - 1];
+        const [tmName, tmTag] = tm.user.name.split("#");
+        return (
+          <SynNode
+            key={tm.user.id}
+            left={pos.left}
+            top={pos.top}
+            initials={heroInitials(tmName)}
+            name={tmName}
+            tag={tmTag ? `#${tmTag}` : ""}
+            sub={`×${tm.tournaments} · ${(tm.winrate * 100).toFixed(0)}% WR`}
+            avBg={TEAMMATE_COLORS[i % TEAMMATE_COLORS.length]}
+          />
+        );
+      })}
+    </div>
+    <div className="aqt-mono flex justify-between border-t border-[color:var(--aqt-border)] px-[18px] py-2.5 text-[11px] text-[color:var(--aqt-fg-dim)]">
+      <span>Edges sized by appearances</span>
+      <span>
+        {totalCount} unique · {totalMaps} maps
+      </span>
+    </div>
+  </>
+);
+
+const AllTeammatesTable = ({
+  teammates,
+  search,
+  onSearchChange
+}: {
+  teammates: UserBestTeammate[];
+  search: string;
+  onSearchChange: (value: string) => void;
+}) => {
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const rows = [...teammates].sort((a, b) => b.tournaments - a.tournaments);
+    if (!q) return rows;
+    return rows.filter((t) => t.user.name.toLowerCase().includes(q));
+  }, [teammates, search]);
+
+  return (
+    <div className="flex flex-col">
+      <div className="border-b border-[color:var(--aqt-border)] px-3.5 py-2.5">
+        <div className="relative">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[color:var(--aqt-fg-faint)]">
+            <circle cx="11" cy="11" r="7" />
+            <path d="m20 20-3.5-3.5" />
+          </svg>
+          <input
+            placeholder="Search teammates…"
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            className="w-full rounded-lg border border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.025)] px-3 py-1.5 pl-8 text-[12.5px] text-[color:var(--aqt-fg)] outline-none"
+          />
+        </div>
+      </div>
+      <div className="max-h-[300px] overflow-y-auto">
+        <table className="aqt-tnum w-full border-collapse text-[12.5px]">
+          <thead>
+            <tr>
+              {["Player", "×played", "WR", "KDA", "MVP"].map((h, i) => (
+                <th
+                  key={h}
+                  className={cnHeader(i === 0)}
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((tm) => {
+              const [tmName, tmTag] = tm.user.name.split("#");
+              return (
+                <tr key={tm.user.id} className="border-b border-[color:var(--aqt-border)] last:border-b-0 hover:bg-[hsl(0_0%_100%/0.02)]">
+                  <td className="px-3.5 py-2">
+                    <Link href={`/users/${playerSlug(tm.user.name)}`} className="inline-flex items-center gap-1.5 hover:text-[color:var(--aqt-teal)]">
+                      <span className="font-semibold text-[color:var(--aqt-fg)]">{tmName}</span>
+                      {tmTag ? <span className="aqt-mono text-[10px] text-[color:var(--aqt-fg-faint)]">#{tmTag}</span> : null}
+                    </Link>
+                  </td>
+                  <td className="aqt-mono px-3.5 py-2 text-right text-[color:var(--aqt-fg-muted)]">{tm.tournaments}</td>
+                  <td
+                    className="aqt-mono px-3.5 py-2 text-right font-semibold"
+                    style={{
+                      color: tm.winrate >= 0.55 ? "var(--aqt-emerald)" : tm.winrate < 0.45 ? "var(--aqt-rose)" : "var(--aqt-amber)"
+                    }}
+                  >
+                    {(tm.winrate * 100).toFixed(0)}%
+                  </td>
+                  <td className="aqt-mono px-3.5 py-2 text-right text-[color:var(--aqt-fg-muted)]">
+                    {formatStat(tm.stats?.[LogStatsName.KDA], 2)}
+                  </td>
+                  <td className="aqt-mono px-3.5 py-2 text-right text-[color:var(--aqt-fg-muted)]">
+                    {formatStat(tm.stats?.[LogStatsName.Performance], 1)}
+                  </td>
+                </tr>
+              );
+            })}
+            {filtered.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-3.5 py-6 text-center text-[12px] text-[color:var(--aqt-fg-dim)]">
+                  No teammates match search
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+const cnHeader = (left: boolean) =>
+  `aqt-mono border-b border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.015)] px-3.5 py-2.5 text-[10px] font-bold uppercase tracking-[0.12em] text-[color:var(--aqt-fg-faint)] ${
+    left ? "text-left" : "text-right"
+  }`;
 
 interface SynNodeProps {
   left: number;

--- a/frontend/src/app/(site)/users/components/redesign/ProfileToolbar.tsx
+++ b/frontend/src/app/(site)/users/components/redesign/ProfileToolbar.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { Share2, GitCompare, Check } from "lucide-react";
+
+interface ProfileToolbarProps {
+  /** Destination for the Compare action. Defaults to the players compare page. */
+  comparePath?: string;
+}
+
+const BTN =
+  "inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.03)] px-2.5 py-1.5 text-[11.5px] font-semibold text-[color:var(--aqt-fg-muted)] transition-colors hover:text-[color:var(--aqt-fg)]";
+
+/**
+ * Header toolbar for the player profile. Share copies the current URL; Compare
+ * links to the existing players-compare page. (Export CSV and Follow are planned
+ * for a later phase — Export needs a per-tab data export, Follow needs backend.)
+ */
+const ProfileToolbar = ({ comparePath = "/users/compare" }: ProfileToolbarProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = async () => {
+    if (typeof window === "undefined") return;
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard unavailable (insecure context / denied) — silently ignore.
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <button type="button" onClick={handleShare} className={BTN} title="Copy link to this profile">
+        {copied ? <Check size={13} /> : <Share2 size={13} />}
+        {copied ? "Copied" : "Share"}
+      </button>
+      <Link href={comparePath} className={BTN} title="Compare players">
+        <GitCompare size={13} />
+        Compare
+      </Link>
+    </div>
+  );
+};
+
+export default ProfileToolbar;

--- a/frontend/src/app/(site)/users/components/redesign/TournamentsHistory.tsx
+++ b/frontend/src/app/(site)/users/components/redesign/TournamentsHistory.tsx
@@ -1,16 +1,25 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { useSearchParams } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { UserTournament, EncounterWithUserStats } from "@/types/user.types";
 import {
   CardSurface,
   PipRow,
   StagePill,
+  MvpPill,
+  mvpRank,
+  ordinal,
   type ScoreKind
 } from "@/app/(site)/users/components/redesign/atoms";
+import MatchLogIndicator from "@/app/(site)/users/components/redesign/MatchLogIndicator";
+import {
+  groupTournamentsByLeague,
+  leagueKey
+} from "@/app/(site)/users/components/redesign/tournaments-history.helpers";
 import DivisionIcon from "@/components/DivisionIcon";
 import PlayerRoleIcon from "@/components/PlayerRoleIcon";
 
@@ -31,28 +40,50 @@ const stageKindForTournament = (t: UserTournament): "group" | "playoffs" | "fina
   return "group";
 };
 
+const roleColor = (role: string | null): string =>
+  role === "Tank" ? "var(--aqt-tank)" : role === "Support" ? "var(--aqt-support)" : "var(--aqt-damage)";
+
 const computeTournamentResults = (tournament: UserTournament, selfUserId: number) => {
   const allEncounters = tournament.encounters ?? [];
   const allPips: ScoreKind[] = [];
-  let won = 0, lost = 0, drawn = 0;
+  let won = 0,
+    lost = 0,
+    drawn = 0;
 
   for (const enc of allEncounters) {
     const homePlayers = enc.home_team?.players ?? [];
     const isUserHome = homePlayers.some((p) => p.user_id === selfUserId);
     for (const match of enc.matches ?? []) {
-      if (!match.score) { drawn++; allPips.push("draw"); continue; }
+      if (!match.score) {
+        drawn++;
+        allPips.push("draw");
+        continue;
+      }
       const userScore = isUserHome ? match.score.home : match.score.away;
       const oppScore = isUserHome ? match.score.away : match.score.home;
-      if (userScore > oppScore) { won++; allPips.push("win"); }
-      else if (userScore < oppScore) { lost++; allPips.push("loss"); }
-      else { drawn++; allPips.push("draw"); }
+      if (userScore > oppScore) {
+        won++;
+        allPips.push("win");
+      } else if (userScore < oppScore) {
+        lost++;
+        allPips.push("loss");
+      } else {
+        drawn++;
+        allPips.push("draw");
+      }
     }
   }
 
   return { pips: allPips.slice(0, 5), won, lost, drawn };
 };
 
-// ─── Encounter row ────────────────────────────────────────────────────────────
+// ─── Encounter row (expanded matches table) ─────────────────────────────────────
+
+const scoreAccent: Record<ScoreKind, string> = {
+  win: "var(--aqt-emerald)",
+  loss: "var(--aqt-rose)",
+  draw: "var(--aqt-amber)"
+};
 
 const EncounterRow = ({
   enc,
@@ -64,17 +95,15 @@ const EncounterRow = ({
   teamId: number;
 }) => {
   const isUserHome =
-    enc.home_team_id === teamId ||
-    (enc.home_team?.players ?? []).some((p) => p.user_id === selfUserId);
+    enc.home_team_id === teamId || (enc.home_team?.players ?? []).some((p) => p.user_id === selfUserId);
 
   const userScore = isUserHome ? enc.score.home : enc.score.away;
   const oppScore = isUserHome ? enc.score.away : enc.score.home;
-  const scoreKind: ScoreKind =
-    userScore > oppScore ? "win" : userScore < oppScore ? "loss" : "draw";
+  const scoreKind: ScoreKind = userScore > oppScore ? "win" : userScore < oppScore ? "loss" : "draw";
 
   const opponent = isUserHome ? enc.away_team?.name : enc.home_team?.name;
 
-  // Collect unique hero images from all maps
+  // Unique hero images across all maps in the encounter.
   const heroImgs: string[] = [];
   const seen = new Set<string>();
   for (const m of enc.matches ?? []) {
@@ -86,42 +115,46 @@ const EncounterRow = ({
     }
   }
 
-  const stageLabel =
-    enc.stage_item?.name ?? enc.stage?.name ?? enc.name ?? "—";
+  const stageLabel = enc.stage_item?.name ?? enc.stage?.name ?? enc.name ?? "—";
 
   return (
     <Link
       href={`/encounters/${enc.id}`}
-      className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-3 border-b border-[color:var(--aqt-border)] px-4 py-2.5 text-[13px] transition-colors last:border-b-0 hover:bg-[hsl(0_0%_100%/0.025)]"
+      className="grid grid-cols-[1fr_auto_auto] items-center gap-3 border-b border-[color:var(--aqt-border)] px-4 py-2.5 text-[13px] transition-colors last:border-b-0 hover:bg-[hsl(0_0%_100%/0.025)] md:grid-cols-[1fr_auto_auto_auto_auto_auto]"
+      style={{ boxShadow: `inset 3px 0 0 0 ${scoreAccent[scoreKind]}` }}
     >
       {/* Stage + opponent */}
-      <div className="flex flex-col gap-0.5 min-w-0">
-        <span className="truncate font-medium text-[color:var(--aqt-fg)]">
-          {opponent ?? enc.name}
-        </span>
-        <span className="aqt-mono text-[10.5px] text-[color:var(--aqt-fg-dim)]">
-          {stageLabel}
-          {enc.has_logs ? (
-            <span className="ml-1.5 text-[color:var(--aqt-emerald)]">· logs</span>
-          ) : null}
-        </span>
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="truncate font-medium text-[color:var(--aqt-fg)]">{opponent ?? enc.name}</span>
+        <span className="aqt-mono text-[10.5px] text-[color:var(--aqt-fg-dim)]">{stageLabel}</span>
       </div>
 
       {/* Hero images */}
-      <div className="hidden items-center gap-0.5 sm:flex">
-        {heroImgs.slice(0, 5).map((src) => (
+      <div className="hidden items-center gap-0.5 md:flex">
+        {heroImgs.slice(0, 6).map((src) => (
           <div key={src} className="relative h-5 w-5 overflow-hidden rounded-sm">
             <Image src={src} alt="" fill sizes="20px" className="object-cover" />
           </div>
         ))}
       </div>
 
+      {/* MVP pills (per map) */}
+      <div className="hidden items-center gap-1 md:flex">
+        {(enc.matches ?? []).map((m) =>
+          m.performance != null ? (
+            <MvpPill key={m.id} rank={mvpRank(m.performance)} label={ordinal(m.performance)} />
+          ) : null
+        )}
+      </div>
+
       {/* Closeness */}
       {enc.closeness != null ? (
-        <span className="aqt-mono hidden text-[11px] text-[color:var(--aqt-fg-dim)] sm:block">
+        <span className="aqt-mono hidden text-[11px] text-[color:var(--aqt-fg-dim)] md:block">
           {(enc.closeness * 100).toFixed(0)}%
         </span>
-      ) : <span />}
+      ) : (
+        <span className="hidden md:block" />
+      )}
 
       {/* Score */}
       <span
@@ -134,181 +167,340 @@ const EncounterRow = ({
       >
         {enc.score.home} – {enc.score.away}
       </span>
+
+      {/* Logs */}
+      <div className="hidden justify-end md:flex" onClick={(e) => e.preventDefault()}>
+        <MatchLogIndicator hasLogs={enc.has_logs} />
+      </div>
     </Link>
   );
 };
 
-// ─── Main component ───────────────────────────────────────────────────────────
+// ─── Single tournament item (row + expanded panel) ──────────────────────────────
 
-const TournamentsHistory = ({ tournaments, selfUserId }: Props) => {
-  const [expanded, setExpanded] = useState<Record<number, boolean>>({});
+const TournamentItem = ({
+  t,
+  selfUserId,
+  isOpen,
+  onToggle
+}: {
+  t: UserTournament;
+  selfUserId: number;
+  isOpen: boolean;
+  onToggle: () => void;
+}) => {
+  const cls = tournamentClass(t);
+  const stats = computeTournamentResults(t, selfUserId);
+  const tournamentNumber = t.number ? `${t.number}` : t.name.split(" | ")[1] ?? "—";
+  const maps = t.maps_won + t.maps_lost;
+  const winrate = maps > 0 ? Math.round((t.maps_won / maps) * 100) : 0;
+  const encounters = t.encounters ?? [];
 
   return (
-    <CardSurface
-      flush
-      title="Tournament history"
-      icon={<span>▢</span>}
-      subtitle="click to expand"
-    >
-      {tournaments.map((t) => {
-        const cls = tournamentClass(t);
-        const isOpen = expanded[t.id] ?? false;
-        const stats = computeTournamentResults(t, selfUserId);
-        const tournamentNumber = t.number ? `${t.number}` : t.name.split(" | ")[1] ?? "—";
-        const tournamentRoleColor =
-          t.role === "Tank"
-            ? "var(--aqt-tank)"
-            : t.role === "Support"
-              ? "var(--aqt-support)"
-              : "var(--aqt-damage)";
+    <>
+      {/* ── Row ── */}
+      <div
+        className={cn("aqt-t-item", cls, isOpen && "expanded")}
+        onClick={onToggle}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") onToggle();
+        }}
+      >
+        <div className="aqt-display text-[24px] font-extrabold leading-none text-[color:var(--aqt-fg-muted)]">
+          {tournamentNumber}
+        </div>
 
-        const encounters = t.encounters ?? [];
-
-        return (
-          <React.Fragment key={t.id}>
-            {/* ── Row ── */}
-            <div
-              className={cn("aqt-t-item", cls, isOpen && "expanded")}
-              onClick={() => setExpanded((s) => ({ ...s, [t.id]: !isOpen }))}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ")
-                  setExpanded((s) => ({ ...s, [t.id]: !isOpen }));
-              }}
+        <div className="flex flex-col gap-1.5">
+          <div className="text-[15px] font-semibold text-[color:var(--aqt-fg)]">
+            <Link
+              href={`/tournaments/${t.id}`}
+              onClick={(e) => e.stopPropagation()}
+              className="hover:text-[color:var(--aqt-teal)]"
             >
-              {/* Placement number */}
-              <div className="aqt-display text-[24px] font-extrabold leading-none text-[color:var(--aqt-fg-muted)]">
-                {tournamentNumber}
-              </div>
+              {t.name}
+            </Link>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-[11px] text-[color:var(--aqt-fg-dim)]">
+            <StagePill kind={stageKindForTournament(t)}>
+              {t.placement === 1 ? "Grand finals" : t.placement <= 3 ? "Playoffs reached" : "Groups"}
+            </StagePill>
+            <span className="inline-flex items-center gap-1">
+              <PlayerRoleIcon role={t.role} size={11} color={roleColor(t.role)} />
+              Team {t.team} · {t.role}
+            </span>
+          </div>
+        </div>
 
-              {/* Name + meta */}
-              <div className="flex flex-col gap-1.5">
-                <div className="text-[15px] font-semibold text-[color:var(--aqt-fg)]">
-                  <Link
-                    href={`/tournaments/${t.id}`}
-                    onClick={(e) => e.stopPropagation()}
-                    className="hover:text-[color:var(--aqt-teal)]"
-                  >
-                    {t.name}
-                  </Link>
-                </div>
-                <div className="flex flex-wrap items-center gap-2 text-[11px] text-[color:var(--aqt-fg-dim)]">
-                  <StagePill kind={stageKindForTournament(t)}>
-                    {t.placement === 1 ? "Grand finals" : t.placement <= 3 ? "Playoffs reached" : "Groups"}
-                  </StagePill>
-                  <span className="inline-flex items-center gap-1">
-                    <PlayerRoleIcon role={t.role} size={11} color={tournamentRoleColor} />
-                    Team {t.team} · {t.role}
-                  </span>
-                </div>
-              </div>
+        <div className="aqt-mono inline-flex items-center gap-2 text-[12px] text-[color:var(--aqt-fg-muted)]">
+          <DivisionIcon division={t.division} tournamentGrid={t.division_grid_version} width={26} height={26} />
+          <span className="aqt-display aqt-tnum text-[20px] font-bold text-[color:var(--aqt-fg)]">
+            {t.placement || "—"}
+          </span>
+          <span className="text-[color:var(--aqt-fg-faint)]">/ {t.count_teams}</span>
+        </div>
 
-              {/* Division + placement */}
-              <div className="aqt-mono inline-flex items-center gap-2 text-[12px] text-[color:var(--aqt-fg-muted)]">
-                <DivisionIcon division={t.division} tournamentGrid={t.division_grid_version} width={26} height={26} />
-                <span className="aqt-display aqt-tnum text-[20px] font-bold text-[color:var(--aqt-fg)]">
-                  {t.placement || "—"}
+        <PipRow results={stats.pips} tall />
+
+        <div
+          className={cn("transition-transform", isOpen && "rotate-180")}
+          style={{ color: isOpen ? "var(--aqt-teal)" : "var(--aqt-fg-faint)" }}
+        >
+          ▾
+        </div>
+      </div>
+
+      {/* ── Expanded panel ── */}
+      {isOpen ? (
+        <div className="border-b border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.012)]">
+          <div className="grid gap-4 p-4 md:grid-cols-[240px_1fr]">
+            {/* Stats */}
+            <div className="flex flex-col gap-3 rounded-[10px] border border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.018)] p-3.5">
+              <div className="flex items-baseline justify-between">
+                <span className="text-[10px] font-bold uppercase tracking-[0.14em] text-[color:var(--aqt-fg-faint)]">
+                  Matches
                 </span>
-                <span className="text-[color:var(--aqt-fg-faint)]">/ {t.count_teams}</span>
+                <span className="aqt-display text-[22px] font-bold leading-none">{t.won + t.lost + t.draw}</span>
               </div>
-
-              <PipRow results={stats.pips} tall />
-
-              <div
-                className={cn("transition-transform", isOpen && "rotate-180")}
-                style={{ color: isOpen ? "var(--aqt-teal)" : "var(--aqt-fg-faint)" }}
-              >
-                ▾
-              </div>
+              <StatLine label="Record">
+                <span style={{ color: "var(--aqt-emerald)" }}>{t.won}W</span>{" "}
+                <span style={{ color: "var(--aqt-rose)" }}>{t.lost}L</span>{" "}
+                <span style={{ color: "var(--aqt-amber)" }}>{t.draw}D</span>
+              </StatLine>
+              <StatLine label="Maps won">
+                <span className="font-semibold text-[color:var(--aqt-fg)]">
+                  {t.maps_won} of {maps}
+                </span>
+              </StatLine>
+              <StatLine label="Winrate">
+                <span
+                  className="font-semibold"
+                  style={{
+                    color: winrate >= 55 ? "var(--aqt-emerald)" : winrate < 45 ? "var(--aqt-rose)" : "var(--aqt-amber)"
+                  }}
+                >
+                  {maps > 0 ? `${winrate}%` : "—"}
+                </span>
+              </StatLine>
+              <StatLine label="Closeness">
+                <span className="font-semibold text-[color:var(--aqt-fg)]">{(t.closeness * 100).toFixed(0)}%</span>
+              </StatLine>
             </div>
 
-            {/* ── Expanded panel ── */}
-            {isOpen ? (
-              <div className="border-b border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.012)]">
-                {/* Stats + Roster row */}
-                <div className="grid gap-4 p-4 md:grid-cols-[220px_1fr]">
-                  {/* Stats */}
-                  <div className="flex flex-col gap-3 rounded-[10px] border border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.018)] p-3.5">
-                    <div className="flex items-baseline justify-between">
-                      <span className="text-[10px] font-bold uppercase tracking-[0.14em] text-[color:var(--aqt-fg-faint)]">Matches</span>
-                      <span className="aqt-display text-[22px] font-bold leading-none">{t.won + t.lost + t.draw}</span>
-                    </div>
-                    <div className="grid grid-cols-[1fr_auto] gap-1.5 text-[12.5px] text-[color:var(--aqt-fg-muted)]">
-                      <span>Record</span>
-                      <span className="aqt-mono">
-                        <span style={{ color: "var(--aqt-emerald)" }}>{t.won}W</span>{" "}
-                        <span style={{ color: "var(--aqt-rose)" }}>{t.lost}L</span>{" "}
-                        <span style={{ color: "var(--aqt-amber)" }}>{t.draw}D</span>
-                      </span>
-                    </div>
-                    <div className="grid grid-cols-[1fr_auto] gap-1.5 text-[12.5px] text-[color:var(--aqt-fg-muted)]">
-                      <span>Maps won</span>
-                      <span className="aqt-mono font-semibold text-[color:var(--aqt-fg)]">
-                        {t.maps_won} of {t.maps_won + t.maps_lost}
-                      </span>
-                    </div>
-                    <div className="grid grid-cols-[1fr_auto] gap-1.5 text-[12.5px] text-[color:var(--aqt-fg-muted)]">
-                      <span>Closeness</span>
-                      <span className="aqt-mono font-semibold text-[color:var(--aqt-fg)]">
-                        {(t.closeness * 100).toFixed(0)}%
-                      </span>
-                    </div>
-                  </div>
-
-                  {/* Roster */}
-                  <div className="rounded-[10px] border border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.018)] p-3.5">
-                    <div className="mb-2.5 text-[10px] font-bold uppercase tracking-[0.14em] text-[color:var(--aqt-fg-faint)]">Roster</div>
-                    <div className="grid gap-2">
-                      {t.players?.slice(0, 5).map((p) => {
-                        const isSelf = p.user_id === selfUserId;
-                        const playerRoleColor =
-                          p.role === "Tank" ? "var(--aqt-tank)"
-                          : p.role === "Support" ? "var(--aqt-support)"
-                          : "var(--aqt-damage)";
-                        return (
-                          <div key={p.id} className="grid grid-cols-[16px_1fr_auto] items-center gap-2">
-                            <PlayerRoleIcon role={p.role} size={14} color={playerRoleColor} />
-                            <div className="flex items-center gap-2 truncate text-[13px]">
-                              <span className={cn("font-semibold", isSelf && "text-[color:var(--aqt-amber)]")}>
-                                {p.name?.split("#")[0]}
-                              </span>
-                              {p.name?.includes("#") ? (
-                                <span className="aqt-mono text-[10px] text-[color:var(--aqt-fg-faint)]">
-                                  #{p.name.split("#")[1]}
-                                </span>
-                              ) : null}
-                            </div>
-                            <DivisionIcon division={p.division} width={26} height={26} />
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-
-                {/* Encounters list */}
-                {encounters.length > 0 ? (
-                  <div className="mx-4 mb-4 overflow-hidden rounded-[10px] border border-[color:var(--aqt-border)]">
-                    <div className="grid grid-cols-[1fr_auto_auto_auto] border-b border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.018)] px-4 py-2">
-                      <span className="text-[10px] font-bold uppercase tracking-[0.12em] text-[color:var(--aqt-fg-faint)]">Opponent</span>
-                      <span className="hidden text-[10px] font-bold uppercase tracking-[0.12em] text-[color:var(--aqt-fg-faint)] sm:block">Heroes</span>
-                      <span className="hidden text-[10px] font-bold uppercase tracking-[0.12em] text-[color:var(--aqt-fg-faint)] sm:block">Close.</span>
-                      <span className="text-right text-[10px] font-bold uppercase tracking-[0.12em] text-[color:var(--aqt-fg-faint)]">Score</span>
-                    </div>
-                    {encounters.map((enc) => (
-                      <EncounterRow
-                        key={enc.id}
-                        enc={enc}
-                        selfUserId={selfUserId}
-                        teamId={t.team_id}
-                      />
-                    ))}
-                  </div>
-                ) : null}
+            {/* Roster (full) */}
+            <div className="rounded-[10px] border border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.018)] p-3.5">
+              <div className="mb-2.5 text-[10px] font-bold uppercase tracking-[0.14em] text-[color:var(--aqt-fg-faint)]">
+                Roster
               </div>
-            ) : null}
-          </React.Fragment>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {(t.players ?? []).map((p) => {
+                  const isSelf = p.user_id === selfUserId;
+                  return (
+                    <div key={p.id} className="grid grid-cols-[16px_1fr_auto] items-center gap-2">
+                      <PlayerRoleIcon role={p.role} size={14} color={roleColor(p.role)} />
+                      <div className="flex min-w-0 items-center gap-1.5 truncate text-[13px]">
+                        <span className={cn("truncate font-semibold", isSelf && "text-[color:var(--aqt-amber)]")}>
+                          {p.name?.split("#")[0]}
+                        </span>
+                        {p.name?.includes("#") ? (
+                          <span className="aqt-mono text-[10px] text-[color:var(--aqt-fg-faint)]">
+                            #{p.name.split("#")[1]}
+                          </span>
+                        ) : null}
+                        {p.is_newcomer ? (
+                          <span
+                            className="aqt-mono rounded-[4px] px-1 py-0.5 text-[8.5px] font-bold uppercase tracking-[0.08em]"
+                            style={{
+                              background: "hsl(174 72% 46% / 0.12)",
+                              color: "var(--aqt-teal)"
+                            }}
+                          >
+                            New
+                          </span>
+                        ) : null}
+                      </div>
+                      <DivisionIcon division={p.division} width={24} height={24} />
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+
+          {/* Encounters table */}
+          {encounters.length > 0 ? (
+            <div className="mx-4 mb-4 overflow-hidden rounded-[10px] border border-[color:var(--aqt-border)]">
+              <div className="grid grid-cols-[1fr_auto_auto] border-b border-[color:var(--aqt-border)] bg-[hsl(0_0%_100%/0.018)] px-4 py-2 md:grid-cols-[1fr_auto_auto_auto_auto_auto]">
+                <HeaderCell>Opponent</HeaderCell>
+                <HeaderCell className="hidden md:block">Heroes</HeaderCell>
+                <HeaderCell className="hidden md:block">MVP</HeaderCell>
+                <HeaderCell className="hidden md:block">Close.</HeaderCell>
+                <HeaderCell className="text-right">Score</HeaderCell>
+                <HeaderCell className="hidden text-right md:block">Logs</HeaderCell>
+              </div>
+              {encounters.map((enc) => (
+                <EncounterRow key={enc.id} enc={enc} selfUserId={selfUserId} teamId={t.team_id} />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+const StatLine = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="grid grid-cols-[1fr_auto] gap-1.5 text-[12.5px] text-[color:var(--aqt-fg-muted)]">
+    <span>{label}</span>
+    <span className="aqt-mono">{children}</span>
+  </div>
+);
+
+const HeaderCell = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <span
+    className={cn(
+      "text-[10px] font-bold uppercase tracking-[0.12em] text-[color:var(--aqt-fg-faint)]",
+      className
+    )}
+  >
+    {children}
+  </span>
+);
+
+// ─── League group (collapsible parent over division entries) ────────────────────
+
+const LeagueGroup = ({
+  name,
+  entries,
+  selfUserId,
+  isOpen,
+  onToggle,
+  isTournamentOpen,
+  onToggleTournament
+}: {
+  name: string;
+  entries: UserTournament[];
+  selfUserId: number;
+  isOpen: boolean;
+  onToggle: () => void;
+  isTournamentOpen: (t: UserTournament) => boolean;
+  onToggleTournament: (t: UserTournament) => void;
+}) => {
+  const bestPlacement = entries.reduce((best, t) => (t.placement && t.placement < best ? t.placement : best), Infinity);
+
+  return (
+    <div className="border-b border-[color:var(--aqt-border)]">
+      <div
+        className="flex cursor-pointer items-center gap-3 px-4 py-3 transition-colors hover:bg-[hsl(0_0%_100%/0.02)]"
+        onClick={onToggle}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") onToggle();
+        }}
+      >
+        <span
+          className="aqt-mono rounded-[5px] border px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em]"
+          style={{
+            background: "hsl(258 60% 62% / 0.1)",
+            borderColor: "hsl(258 60% 62% / 0.25)",
+            color: "var(--aqt-violet)"
+          }}
+        >
+          League
+        </span>
+        <span className="flex-1 truncate text-[15px] font-semibold text-[color:var(--aqt-fg)]">{name}</span>
+        <span className="aqt-mono text-[11px] text-[color:var(--aqt-fg-dim)]">
+          {entries.length} divisions
+          {bestPlacement !== Infinity ? ` · best #${bestPlacement}` : ""}
+        </span>
+        <div
+          className={cn("transition-transform", isOpen && "rotate-180")}
+          style={{ color: isOpen ? "var(--aqt-teal)" : "var(--aqt-fg-faint)" }}
+        >
+          ▾
+        </div>
+      </div>
+
+      {isOpen ? (
+        <div className="border-t border-[color:var(--aqt-border)] pl-4">
+          {entries.map((t) => (
+            <TournamentItem
+              key={t.id}
+              t={t}
+              selfUserId={selfUserId}
+              isOpen={isTournamentOpen(t)}
+              onToggle={() => onToggleTournament(t)}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+// ─── Main component ─────────────────────────────────────────────────────────────
+
+const TournamentsHistory = ({ tournaments, selfUserId }: Props) => {
+  const searchParams = useSearchParams();
+  const selectedId = useMemo(() => {
+    const raw = searchParams?.get("selectedTournamentId");
+    const parsed = raw ? Number(raw) : NaN;
+    return Number.isFinite(parsed) ? parsed : null;
+  }, [searchParams]);
+
+  // Group consecutive league entries (sharing the league-name prefix) under one parent.
+  const grouped = useMemo(() => groupTournamentsByLeague(tournaments), [tournaments]);
+
+  const [expanded, setExpanded] = useState<Record<number, boolean>>({});
+  const [expandedLeagues, setExpandedLeagues] = useState<Record<string, boolean>>({});
+
+  const syncUrl = (id: number, open: boolean) => {
+    if (typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    if (open) url.searchParams.set("selectedTournamentId", String(id));
+    else url.searchParams.delete("selectedTournamentId");
+    window.history.replaceState(null, "", url.toString());
+  };
+
+  const isTournamentOpen = (t: UserTournament) => expanded[t.id] ?? t.id === selectedId;
+
+  const toggleTournament = (t: UserTournament) => {
+    const next = !isTournamentOpen(t);
+    setExpanded((s) => ({ ...s, [t.id]: next }));
+    syncUrl(t.id, next);
+  };
+
+  const isLeagueOpen = (name: string, entries: UserTournament[]) =>
+    expandedLeagues[name] ?? entries.some((t) => t.id === selectedId);
+
+  return (
+    <CardSurface flush title="Tournament history" icon={<span>▢</span>} subtitle="click to expand">
+      {grouped.map((entry) => {
+        if (!Array.isArray(entry)) {
+          return (
+            <TournamentItem
+              key={entry.id}
+              t={entry}
+              selfUserId={selfUserId}
+              isOpen={isTournamentOpen(entry)}
+              onToggle={() => toggleTournament(entry)}
+            />
+          );
+        }
+        const name = leagueKey(entry[0]);
+        return (
+          <LeagueGroup
+            key={name}
+            name={name}
+            entries={entry}
+            selfUserId={selfUserId}
+            isOpen={isLeagueOpen(name, entry)}
+            onToggle={() => setExpandedLeagues((s) => ({ ...s, [name]: !isLeagueOpen(name, entry) }))}
+            isTournamentOpen={isTournamentOpen}
+            onToggleTournament={toggleTournament}
+          />
         );
       })}
     </CardSurface>

--- a/frontend/src/app/(site)/users/components/redesign/atoms.tsx
+++ b/frontend/src/app/(site)/users/components/redesign/atoms.tsx
@@ -124,6 +124,30 @@ export const MvpPill = ({ rank, label, className }: { rank: MvpRank; label: stri
   <span className={cn("aqt-mvp-pill", rank !== "default" && rank, className)}>{label}</span>
 );
 
+/** Map a 1-based per-match performance placement to an MvpPill rank. */
+export const mvpRank = (performance: number | null | undefined): MvpRank => {
+  if (performance === 1) return "gold";
+  if (performance === 2) return "silver";
+  if (performance === 3) return "bronze";
+  return "default";
+};
+
+/** English ordinal for a positive integer (1 → "1st", 2 → "2nd", …). */
+export const ordinal = (n: number): string => {
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
+  switch (n % 10) {
+    case 1:
+      return `${n}st`;
+    case 2:
+      return `${n}nd`;
+    case 3:
+      return `${n}rd`;
+    default:
+      return `${n}th`;
+  }
+};
+
 export const PipRow = ({ results, tall = false, className }: { results: ScoreKind[]; tall?: boolean; className?: string }) => (
   <span className={cn("inline-flex gap-[3px]", className)}>
     {results.map((r, i) => (

--- a/frontend/src/app/(site)/users/components/redesign/tournaments-history.helpers.test.ts
+++ b/frontend/src/app/(site)/users/components/redesign/tournaments-history.helpers.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  groupTournamentsByLeague,
+  leagueKey
+} from "@/app/(site)/users/components/redesign/tournaments-history.helpers";
+import type { UserTournament } from "@/types/user.types";
+
+const buildTournament = (id: number, name: string, isLeague: boolean): UserTournament =>
+  ({
+    id,
+    name,
+    is_league: isLeague
+  }) as UserTournament;
+
+describe("leagueKey", () => {
+  it("extracts the prefix before the pipe separator", () => {
+    expect(leagueKey(buildTournament(1, "Winter League | Division 2", true))).toBe("Winter League");
+  });
+
+  it("returns the whole name when there is no separator", () => {
+    expect(leagueKey(buildTournament(1, "Open Cup", false))).toBe("Open Cup");
+  });
+});
+
+describe("groupTournamentsByLeague", () => {
+  it("collapses consecutive same-league divisions into one group", () => {
+    const tournaments = [
+      buildTournament(1, "Winter League | Division 1", true),
+      buildTournament(2, "Winter League | Division 2", true),
+      buildTournament(3, "Winter League | Division 3", true)
+    ];
+
+    const result = groupTournamentsByLeague(tournaments);
+
+    expect(result).toHaveLength(1);
+    expect(Array.isArray(result[0])).toBe(true);
+    expect((result[0] as UserTournament[]).map((t) => t.id)).toEqual([1, 2, 3]);
+  });
+
+  it("keeps non-league tournaments as standalone entries", () => {
+    const tournaments = [
+      buildTournament(1, "Open Cup", false),
+      buildTournament(2, "Charity Bowl", false)
+    ];
+
+    const result = groupTournamentsByLeague(tournaments);
+
+    expect(result).toHaveLength(2);
+    expect(Array.isArray(result[0])).toBe(false);
+    expect((result[0] as UserTournament).id).toBe(1);
+  });
+
+  it("splits adjacent groups belonging to different leagues", () => {
+    const tournaments = [
+      buildTournament(1, "Winter League | Division 1", true),
+      buildTournament(2, "Winter League | Division 2", true),
+      buildTournament(3, "Summer League | Division 1", true)
+    ];
+
+    const result = groupTournamentsByLeague(tournaments);
+
+    expect(result).toHaveLength(2);
+    expect((result[0] as UserTournament[]).map((t) => t.id)).toEqual([1, 2]);
+    expect((result[1] as UserTournament[]).map((t) => t.id)).toEqual([3]);
+  });
+
+  it("preserves order when leagues and standalone tournaments interleave", () => {
+    const tournaments = [
+      buildTournament(1, "Open Cup", false),
+      buildTournament(2, "Winter League | Division 1", true),
+      buildTournament(3, "Winter League | Division 2", true),
+      buildTournament(4, "Charity Bowl", false)
+    ];
+
+    const result = groupTournamentsByLeague(tournaments);
+
+    expect(result).toHaveLength(3);
+    expect((result[0] as UserTournament).id).toBe(1);
+    expect((result[1] as UserTournament[]).map((t) => t.id)).toEqual([2, 3]);
+    expect((result[2] as UserTournament).id).toBe(4);
+  });
+});

--- a/frontend/src/app/(site)/users/components/redesign/tournaments-history.helpers.ts
+++ b/frontend/src/app/(site)/users/components/redesign/tournaments-history.helpers.ts
@@ -1,0 +1,41 @@
+import type { UserTournament } from "@/types/user.types";
+
+/** League grouping key: the prefix before " | " in the tournament name. */
+export const leagueKey = (t: UserTournament): string => t.name.split(" | ")[0];
+
+export type TournamentGroup = UserTournament | UserTournament[];
+
+/**
+ * Group consecutive league tournaments (those with `is_league` sharing the same
+ * league-name prefix) into arrays; non-league tournaments remain standalone
+ * entries. Input order is preserved, so a league's divisions stay contiguous
+ * exactly as the API returns them.
+ */
+export const groupTournamentsByLeague = (tournaments: UserTournament[]): TournamentGroup[] => {
+  const result: TournamentGroup[] = [];
+  let currentLeague: UserTournament[] = [];
+  let flag = "";
+
+  tournaments.forEach((t) => {
+    if (t.is_league) {
+      const key = leagueKey(t);
+      if (flag && flag !== key) {
+        result.push(currentLeague);
+        currentLeague = [];
+      }
+      flag = key;
+      currentLeague.push(t);
+    } else {
+      if (currentLeague.length > 0) {
+        result.push(currentLeague);
+        currentLeague = [];
+        flag = "";
+      }
+      result.push(t);
+    }
+  });
+
+  if (currentLeague.length > 0) result.push(currentLeague);
+
+  return result;
+};


### PR DESCRIPTION
Tournaments tab:
- regroup league divisions under one expandable parent (is_league + name prefix)
- restore per-match MVP pills (performance), closeness, full roster, winrate
- color-code match results

Matches tab:
- add MVP pills + closeness columns, clickable rows, readable stage labels
- new MatchLogIndicator (replaces the bare glyph; download-ready slot)
- add "MVP 1st" filter chip

Maps tab:
- restore per-hero hover popover (winrate/games/record/playtime%)
- restore tournament filter, rows-per-page + pagination, sort/order controls

Heroes tab:
- spotlight quick-stats with deltas, Highlights/All-stats toggle
- sortable ~31-stat comparison table with personal-best marker

Overview & header:
- teammates "All ->" toggles to a full table (x-played/WR/KDA/MVP + search)
- remove Aura badge; add Share/Compare toolbar

Achievements:
- add sort control (rarity/name/earned)

Backend-dependent items (log download, locked-achievement progress, teammate maps-together, Follow) are intentionally deferred.