### PR TITLE
feat(heroes-compare): redesign Hero Compare page + team data

### DIFF
--- a/backend/app-service/src/schemas/hero.py
+++ b/backend/app-service/src/schemas/hero.py
@@ -73,6 +73,8 @@ class HeroLeaderboardEntry(BaseModel):
     player_name: str
     role: enums.HeroClass | None
     div: int
+    team: str | None = None
+    team_id: int | None = None
     games_played: int
     playtime_seconds: float
     per10_eliminations: float

--- a/backend/app-service/src/services/hero/flows.py
+++ b/backend/app-service/src/services/hero/flows.py
@@ -40,6 +40,8 @@ async def get_hero_leaderboard(
                 player_name=row.player_name,
                 role=row.role,
                 div=row.div,
+                team=row.team,
+                team_id=row.team_id,
                 games_played=int(row.games_played),
                 playtime_seconds=float(row.playtime_seconds),
                 per10_eliminations=float(row.per10_eliminations),

--- a/backend/app-service/src/services/hero/service.py
+++ b/backend/app-service/src/services/hero/service.py
@@ -480,6 +480,8 @@ async def get_hero_leaderboard(
             models.Player.name,
             models.Player.role,
             division_case_expr(models.Player.rank, grid).label("div"),
+            models.Team.id.label("team_id"),
+            models.Team.name.label("team"),
             sa.func.row_number()
             .over(
                 partition_by=models.Player.user_id,
@@ -487,6 +489,7 @@ async def get_hero_leaderboard(
             )
             .label("rn"),
         )
+        .join(models.Team, models.Team.id == models.Player.team_id)
         .where(models.Player.is_substitution.is_(False))
     ).subquery("player_rn")
 
@@ -496,6 +499,8 @@ async def get_hero_leaderboard(
             player_rn_subq.c.name,
             player_rn_subq.c.role,
             player_rn_subq.c.div,
+            player_rn_subq.c.team_id,
+            player_rn_subq.c.team,
         ).where(player_rn_subq.c.rn == 1)
     ).subquery("player_latest")
 
@@ -516,6 +521,8 @@ async def get_hero_leaderboard(
             player_latest_subq.c.name.label("player_name"),
             player_latest_subq.c.role,
             player_latest_subq.c.div,
+            player_latest_subq.c.team_id,
+            player_latest_subq.c.team,
             stats_agg_cte.c.games_played,
             stats_agg_cte.c.playtime_seconds,
             stats_agg_cte.c.per10_eliminations,

--- a/backend/tournament-service/src/schemas/hero.py
+++ b/backend/tournament-service/src/schemas/hero.py
@@ -73,6 +73,8 @@ class HeroLeaderboardEntry(BaseModel):
     player_name: str
     role: enums.HeroClass | None
     div: int
+    team: str | None = None
+    team_id: int | None = None
     games_played: int
     playtime_seconds: float
     per10_eliminations: float

--- a/backend/tournament-service/src/services/hero/flows.py
+++ b/backend/tournament-service/src/services/hero/flows.py
@@ -36,6 +36,8 @@ async def get_hero_leaderboard(
                 player_name=row.player_name,
                 role=row.role,
                 div=row.div,
+                team=row.team,
+                team_id=row.team_id,
                 games_played=int(row.games_played),
                 playtime_seconds=float(row.playtime_seconds),
                 per10_eliminations=float(row.per10_eliminations),

--- a/backend/tournament-service/src/services/hero/service.py
+++ b/backend/tournament-service/src/services/hero/service.py
@@ -600,13 +600,17 @@ async def get_hero_leaderboard(
             models.Player.name,
             models.Player.role,
             division_case_expr(models.Player.rank, grid).label("div"),
+            models.Team.id.label("team_id"),
+            models.Team.name.label("team"),
             sa.func.row_number()
             .over(
                 partition_by=models.Player.user_id,
                 order_by=models.Player.tournament_id.desc(),
             )
             .label("rn"),
-        ).where(models.Player.is_substitution.is_(False))
+        )
+        .join(models.Team, models.Team.id == models.Player.team_id)
+        .where(models.Player.is_substitution.is_(False))
     ).subquery("player_rn")
 
     player_latest_subq = (
@@ -615,6 +619,8 @@ async def get_hero_leaderboard(
             player_rn_subq.c.name,
             player_rn_subq.c.role,
             player_rn_subq.c.div,
+            player_rn_subq.c.team_id,
+            player_rn_subq.c.team,
         ).where(player_rn_subq.c.rn == 1)
     ).subquery("player_latest")
 
@@ -635,6 +641,8 @@ async def get_hero_leaderboard(
             player_latest_subq.c.name.label("player_name"),
             player_latest_subq.c.role,
             player_latest_subq.c.div,
+            player_latest_subq.c.team_id,
+            player_latest_subq.c.team,
             stats_agg_cte.c.games_played,
             stats_agg_cte.c.playtime_seconds,
             stats_agg_cte.c.per10_eliminations,

--- a/frontend/src/app/(site)/users/compare/components/SearchableImageSelect.tsx
+++ b/frontend/src/app/(site)/users/compare/components/SearchableImageSelect.tsx
@@ -6,6 +6,7 @@ import { Check, ChevronsUpDown } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 import {
   Command,
   CommandEmpty,
@@ -37,6 +38,8 @@ interface SearchableImageSelectProps {
   isLoading?: boolean;
   /** Whether the selector is disabled (loading or error). */
   disabled?: boolean;
+  /** Override the trigger's appearance (border/background). Layout is fixed. */
+  triggerClassName?: string;
 }
 
 const SearchableImageSelect = ({
@@ -47,6 +50,7 @@ const SearchableImageSelect = ({
   searchPlaceholder = "Search...",
   isLoading = false,
   disabled = false,
+  triggerClassName,
 }: SearchableImageSelectProps) => {
   const [open, setOpen] = useState(false);
 
@@ -66,7 +70,10 @@ const SearchableImageSelect = ({
           role="combobox"
           aria-expanded={open}
           disabled={disabled}
-          className="h-10 w-full justify-between border-border/60 bg-background/15 font-normal hover:bg-background/20"
+          className={cn(
+            "h-10 w-full justify-between font-normal",
+            triggerClassName ?? "border-border/60 bg-background/15 hover:bg-background/20"
+          )}
         >
           <div className="flex items-center gap-2 overflow-hidden">
             {selected?.imageSrc ? (

--- a/frontend/src/app/(site)/users/heroes-compare/components/BarRow.tsx
+++ b/frontend/src/app/(site)/users/heroes-compare/components/BarRow.tsx
@@ -1,47 +1,77 @@
+import { memo } from "react";
 import Link from "next/link";
 
 import { HeroLeaderboardEntry } from "@/types/hero.types";
 import { toUserSlug } from "@/app/(site)/users/components/users-overview/utils";
 
+import { teamDotBackground } from "../utils/teamColor";
 import RankBadge from "./RankBadge";
 
 interface BarRowProps {
   entry: HeroLeaderboardEntry;
   rank: number;
   value: number;
+  minValue: number;
   maxValue: number;
   barColor: string;
   formatValue: (v: number) => string;
-  isEven: boolean;
+  isHighlighted: boolean;
+  onHoverUser: (userId: number | null) => void;
 }
 
-const BarRow = ({ entry, rank, value, maxValue, barColor, formatValue, isEven }: BarRowProps) => {
-  const barPct = Math.max((value / maxValue) * 100, 0);
+const BarRow = ({
+  entry,
+  rank,
+  value,
+  minValue,
+  maxValue,
+  barColor,
+  formatValue,
+  isHighlighted,
+  onHoverUser,
+}: BarRowProps) => {
+  // Min-anchored scaling so the smallest value stays visible (matches mockup).
+  const span = maxValue - minValue || 1;
+  const barPct = Math.min(Math.max(18 + ((value - minValue) / span) * 82, 0), 100);
+
   return (
     <Link
       href={`/users/${toUserSlug(entry.username)}`}
+      title={`${entry.username} · ${entry.team ?? "—"} · D${entry.div}`}
+      onMouseEnter={() => onHoverUser(entry.user_id)}
+      onMouseLeave={() => onHoverUser(null)}
       className={[
-        "flex items-center gap-3 px-4 py-[9px]",
-        "cursor-pointer transition-colors duration-150 hover:bg-muted/25",
-        isEven ? "bg-muted/[0.06]" : "",
+        "grid grid-cols-[26px_116px_1fr_52px] items-center gap-[9px] border-b border-white/[0.04] px-3.5 py-2",
+        "cursor-pointer transition-colors",
+        isHighlighted
+          ? "bg-[color-mix(in_srgb,var(--aqt-teal)_8%,transparent)]"
+          : "hover:bg-white/[0.025]",
       ].join(" ")}
-      title={entry.username}
     >
       <RankBadge rank={rank} />
-      <span className="w-32 shrink-0 truncate text-right text-sm font-medium leading-normal">
-        {entry.username}
-      </span>
-      <div className="relative h-[22px] flex-1 overflow-hidden rounded-[3px] bg-background/20 ring-1 ring-border/30">
+      <div className="flex min-w-0 items-center gap-2">
+        <span
+          className="h-2 w-2 shrink-0 rounded-[2px]"
+          style={{ background: teamDotBackground(entry.team, entry.team_id) }}
+        />
+        <span className="truncate text-[13px] font-medium text-[var(--aqt-fg)]">
+          {entry.username}
+        </span>
+      </div>
+      <div className="relative h-5 overflow-hidden rounded-[4px] bg-white/[0.03] ring-1 ring-inset ring-[var(--aqt-border-2)]">
         <div
-          className={`absolute inset-y-0 left-0 rounded-[3px] transition-all duration-300 ${barColor}`}
+          className={`absolute inset-y-0 left-0 rounded-[4px] transition-[width] duration-500 ${barColor}`}
           style={{ width: `${barPct}%`, minWidth: barPct > 0 ? "3px" : "0" }}
         />
       </div>
-      <span className="w-14 shrink-0 text-left font-mono text-sm font-semibold tabular-nums text-foreground/85">
+      <span className="text-right font-[family-name:var(--aqt-mono)] text-[12.5px] font-semibold tabular-nums text-[var(--aqt-fg)]/90">
         {formatValue(value)}
       </span>
     </Link>
   );
 };
 
-export default BarRow;
+// Memoized: hovering one player flips `isHighlighted` on only the matching
+// rows, so unchanged rows across all 5 columns skip re-render (props are
+// stable refs / primitives from the module-level COL config).
+export default memo(BarRow);

--- a/frontend/src/app/(site)/users/heroes-compare/components/HeroCompareHero.tsx
+++ b/frontend/src/app/(site)/users/heroes-compare/components/HeroCompareHero.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import React, { useMemo } from "react";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+
+import { Hero, HeroLeaderboardEntry } from "@/types/hero.types";
+import { heroVariantFromRole } from "@/components/hero/heroRole";
+
+import { COL } from "../config/stat-columns";
+
+// Hexagon lattice + dual radial glows — the only raw CSS the redesign needs
+// (not expressible as utilities). Mirrors `.hero/.hex/.glow-1/.glow-2` from the
+// imported mockup.
+const HEX_BG =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='92.4'%3E%3Cpolygon points='40,1 79,23.2 79,69.2 40,91.4 1,69.2 1,23.2' fill='none' stroke='white' stroke-width='0.8' opacity='0.055'/%3E%3C/svg%3E\")";
+const GLOW_1 = "radial-gradient(ellipse at 30% 50%, hsl(174 72% 46% / 0.16), transparent 62%)";
+const GLOW_2 = "radial-gradient(ellipse at 70% 30%, hsl(340 75% 58% / 0.12), transparent 58%)";
+
+const DISPLAY = "font-[family-name:var(--aqt-display)]";
+
+interface SummaryStat {
+  label: string;
+  value: React.ReactNode;
+  sub: string;
+  /** Render the value at the smaller size used for player-name values. */
+  small?: boolean;
+  /** Render the value in the teal accent (used for Role). */
+  accent?: boolean;
+}
+
+interface HeroCompareHeroProps {
+  selectedHero: Hero | undefined;
+  rows: HeroLeaderboardEntry[];
+}
+
+const HeroCompareHero = ({ selectedHero, rows }: HeroCompareHeroProps) => {
+  const stats = useMemo<SummaryStat[]>(() => {
+    const variant = heroVariantFromRole(selectedHero?.type ?? selectedHero?.role);
+    const sigKey =
+      variant === "support"
+        ? "per10_healing"
+        : variant === "tank"
+          ? "per10_damage_blocked"
+          : "per10_damage";
+    const sigShort = variant === "support" ? "Healing" : variant === "tank" ? "Blocked" : "Damage";
+    const sigDef = COL[sigKey];
+    const kdDef = COL.kd;
+    const roleLabel = selectedHero?.type ?? selectedHero?.role ?? "—";
+
+    const topSig = rows.length
+      ? rows.reduce((best, r) => (sigDef.getValue(r) > sigDef.getValue(best) ? r : best))
+      : undefined;
+    const bestKd = rows.length ? rows.reduce((best, r) => (r.kd > best.kd ? r : best)) : undefined;
+
+    return [
+      {
+        label: "Players ranked",
+        value: rows.length || "—",
+        sub: selectedHero ? `with logged ${selectedHero.name} time` : "pick a hero to rank",
+      },
+      {
+        label: `Top ${sigShort}`,
+        value: topSig ? topSig.username : "—",
+        sub: topSig ? `${sigDef.formatValue(sigDef.getValue(topSig))} / 10` : "",
+        small: true,
+      },
+      {
+        label: "Best K/D",
+        value: bestKd ? kdDef.formatValue(bestKd.kd) : "—",
+        sub: bestKd ? bestKd.username : "",
+      },
+      {
+        label: "Role",
+        value: roleLabel,
+        sub: selectedHero ? `${selectedHero.name} · 5 stat columns` : "",
+        small: true,
+        accent: true,
+      },
+    ];
+  }, [selectedHero, rows]);
+
+  return (
+    <section className="relative overflow-hidden rounded-[var(--aqt-radius)] border border-[var(--aqt-border)] bg-[var(--aqt-bg)] px-6 py-8 md:px-10 md:py-[34px]">
+      <div className="pointer-events-none absolute inset-0" style={{ backgroundImage: HEX_BG, backgroundSize: "80px 92.4px" }} />
+      <div className="pointer-events-none absolute -left-[5%] -top-[15%] h-[130%] w-[65%]" style={{ background: GLOW_1 }} />
+      <div className="pointer-events-none absolute -top-[25%] right-0 h-full w-[55%]" style={{ background: GLOW_2 }} />
+
+      <div className="relative grid items-end gap-7 lg:grid-cols-[1fr_auto] lg:gap-12">
+        <div>
+          <p className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--aqt-fg-faint)]">
+            <Link href="/users" className="transition-colors hover:text-[var(--aqt-teal)]">
+              Users
+            </Link>
+            <ChevronRight className="h-3 w-3 opacity-50" />
+            <span>Hero compare</span>
+          </p>
+          <h1 className={`${DISPLAY} my-3 text-4xl font-bold uppercase leading-[1.05] tracking-[0.02em] md:text-5xl`}>
+            Who plays it <span className="text-[var(--aqt-teal)]">best</span>?
+          </h1>
+          <p className="max-w-[44rem] text-sm text-[var(--aqt-fg-muted)]">
+            Pick a hero and rank every player who&apos;s logged time on it. Each column ranks the same roster
+            independently — so the elims leader and the healing leader can be different people, side by side.
+          </p>
+        </div>
+
+        <div className="grid min-w-0 grid-cols-2 gap-x-7 gap-y-5 text-left sm:grid-cols-4 lg:text-right">
+          {stats.map((stat) => (
+            <div key={stat.label} className="flex flex-col gap-1 lg:items-end">
+              <span className="text-[9.5px] font-bold uppercase tracking-[0.14em] text-[var(--aqt-fg-faint)]">
+                {stat.label}
+              </span>
+              <span
+                className={`${DISPLAY} font-bold leading-none tabular-nums ${stat.small ? "text-2xl" : "text-3xl"} ${
+                  stat.accent ? "text-[var(--aqt-teal)]" : "text-[var(--aqt-fg)]"
+                }`}
+              >
+                {stat.value}
+              </span>
+              {stat.sub ? <span className="text-[10.5px] text-[var(--aqt-fg-dim)]">{stat.sub}</span> : null}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HeroCompareHero;

--- a/frontend/src/app/(site)/users/heroes-compare/components/HeroLeaderboardContent.tsx
+++ b/frontend/src/app/(site)/users/heroes-compare/components/HeroLeaderboardContent.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import { Sword } from "lucide-react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 
-import { Card } from "@/components/ui/card";
-import GlassGlow from "@/app/(site)/users/compare/components/GlassGlow";
-import { getGlowVarsFromColor } from "@/app/(site)/users/compare/utils";
 import heroService from "@/services/hero.service";
 import tournamentService from "@/services/tournament.service";
 import { type SearchableImageOption } from "@/app/(site)/users/compare/components/SearchableImageSelect";
@@ -18,14 +15,9 @@ import {
   NUM_COLUMNS,
   getDefaultColumnKeys,
 } from "../config/stat-columns";
+import HeroCompareHero from "./HeroCompareHero";
 import HeroLeaderboardFiltersCard from "./HeroLeaderboardFiltersCard";
 import HeroLeaderboardTable from "./HeroLeaderboardTable";
-
-const DEFAULT_LG_VARS = {
-  "--lg-a": "14 165 233",
-  "--lg-b": "16 185 129",
-  "--lg-c": "244 63 94",
-} as React.CSSProperties;
 
 const HeroLeaderboardContent = () => {
   const searchParams = useSearchParams();
@@ -120,21 +112,21 @@ const HeroLeaderboardContent = () => {
     updateParams({ [`dir${colIndex}`]: sortDirs[colIndex] === "asc" ? "desc" : "asc" });
   };
 
-  const heroGlowVars = useMemo(
-    () => getGlowVarsFromColor(selectedHero?.color ?? null),
-    [selectedHero?.color]
-  );
-
-  const lgVars = (
-    heroGlowVars
-      ? { "--lg-a": heroGlowVars["--lg-a"], "--lg-b": heroGlowVars["--lg-b"], "--lg-c": heroGlowVars["--lg-c"] }
-      : DEFAULT_LG_VARS
-  ) as React.CSSProperties;
+  const handleResetColumns = () => {
+    const updates: Record<string, undefined> = {};
+    for (let i = 0; i < NUM_COLUMNS; i++) {
+      updates[`col${i}`] = undefined;
+      updates[`dir${i}`] = undefined;
+    }
+    updateParams(updates);
+  };
 
   const rows = leaderboardQuery.data?.results ?? [];
 
   return (
-    <div className="liquid-glass space-y-4" style={lgVars}>
+    <div className="space-y-[22px]">
+      <HeroCompareHero selectedHero={selectedHero} rows={rows} />
+
       <HeroLeaderboardFiltersCard
         heroId={heroId}
         tournamentId={tournamentId}
@@ -146,18 +138,17 @@ const HeroLeaderboardContent = () => {
         isErrorTournaments={tournamentsQuery.isError}
         onHeroChange={(v) => updateParams({ hero_id: v ? Number(v) : undefined })}
         onTournamentChange={(v) => updateParams({ tournament_id: v ? Number(v) : undefined })}
+        onResetColumns={handleResetColumns}
+        resetDisabled={heroId === undefined}
       />
 
       {heroId === undefined ? (
-        <Card className="relative overflow-hidden">
-          <GlassGlow />
-          <div className="relative flex flex-col items-center justify-center gap-3 py-20 text-center">
-            <Sword className="h-10 w-10 text-muted-foreground/30" />
-            <p className="text-sm leading-relaxed text-muted-foreground">
-              Select a hero above to view the leaderboard
-            </p>
-          </div>
-        </Card>
+        <div className="flex flex-col items-center justify-center gap-3.5 rounded-[var(--aqt-radius)] border border-[var(--aqt-border)] bg-[var(--aqt-card)] py-[90px] text-center">
+          <Sword className="h-10 w-10 text-[var(--aqt-fg-faint)] opacity-50" />
+          <p className="max-w-sm text-sm leading-relaxed text-[var(--aqt-fg-dim)]">
+            Select a hero above to rank every player who&apos;s logged time on it.
+          </p>
+        </div>
       ) : (
         <HeroLeaderboardTable
           selectedHero={selectedHero}

--- a/frontend/src/app/(site)/users/heroes-compare/components/HeroLeaderboardFiltersCard.tsx
+++ b/frontend/src/app/(site)/users/heroes-compare/components/HeroLeaderboardFiltersCard.tsx
@@ -1,11 +1,8 @@
-import { Sword } from "lucide-react";
+import { RotateCcw } from "lucide-react";
 
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { TypographyH4 } from "@/components/ui/typography";
 import SearchableImageSelect, {
   type SearchableImageOption,
 } from "@/app/(site)/users/compare/components/SearchableImageSelect";
-import GlassGlow from "@/app/(site)/users/compare/components/GlassGlow";
 
 interface HeroLeaderboardFiltersCardProps {
   heroId: number | undefined;
@@ -18,7 +15,13 @@ interface HeroLeaderboardFiltersCardProps {
   isErrorTournaments: boolean;
   onHeroChange: (value: string | undefined) => void;
   onTournamentChange: (value: string | undefined) => void;
+  onResetColumns: () => void;
+  resetDisabled: boolean;
 }
+
+const TRIGGER =
+  "border-[var(--aqt-border-2)] bg-white/[0.025] text-[var(--aqt-fg)] hover:bg-white/[0.04]";
+const LABEL = "text-[10px] font-bold uppercase tracking-[0.14em] text-[var(--aqt-fg-faint)]";
 
 const HeroLeaderboardFiltersCard = ({
   heroId,
@@ -31,41 +34,49 @@ const HeroLeaderboardFiltersCard = ({
   isErrorTournaments,
   onHeroChange,
   onTournamentChange,
+  onResetColumns,
+  resetDisabled,
 }: HeroLeaderboardFiltersCardProps) => (
-  <Card className="relative overflow-hidden">
-    <GlassGlow />
-    <CardHeader className="relative pb-3">
-      <div className="flex items-center gap-2">
-        <Sword className="h-5 w-5" />
-        <TypographyH4>Hero Performance Leaderboard</TypographyH4>
-      </div>
-      <p className="text-sm leading-relaxed text-muted-foreground">
-        Compare player performance on a specific hero. Each column is independently ranked.
-      </p>
-    </CardHeader>
-    <CardContent className="relative">
-      <div className="grid gap-3 sm:grid-cols-2">
-        <SearchableImageSelect
-          value={heroId !== undefined ? String(heroId) : undefined}
-          onValueChange={(v) => onHeroChange(v || undefined)}
-          options={heroOptions}
-          placeholder="Select hero"
-          searchPlaceholder="Search heroes..."
-          isLoading={isLoadingHeroes}
-          disabled={isLoadingHeroes || isErrorHeroes}
-        />
-        <SearchableImageSelect
-          value={tournamentId !== undefined ? String(tournamentId) : undefined}
-          onValueChange={(v) => onTournamentChange(v || undefined)}
-          options={tournamentOptions}
-          placeholder="All tournaments"
-          searchPlaceholder="Search tournaments..."
-          isLoading={isLoadingTournaments}
-          disabled={isLoadingTournaments || isErrorTournaments}
-        />
-      </div>
-    </CardContent>
-  </Card>
+  <section className="grid items-end gap-3.5 rounded-[var(--aqt-radius)] border border-[var(--aqt-border)] bg-[var(--aqt-card)] px-5 py-[18px] sm:grid-cols-2 lg:grid-cols-[1fr_1fr_auto]">
+    <div className="flex min-w-0 flex-col gap-2">
+      <span className={LABEL}>Hero</span>
+      <SearchableImageSelect
+        value={heroId !== undefined ? String(heroId) : undefined}
+        onValueChange={(v) => onHeroChange(v || undefined)}
+        options={heroOptions}
+        placeholder="Select hero"
+        searchPlaceholder="Search heroes..."
+        isLoading={isLoadingHeroes}
+        disabled={isLoadingHeroes || isErrorHeroes}
+        triggerClassName={TRIGGER}
+      />
+    </div>
+
+    <div className="flex min-w-0 flex-col gap-2">
+      <span className={LABEL}>Tournament scope</span>
+      <SearchableImageSelect
+        value={tournamentId !== undefined ? String(tournamentId) : undefined}
+        onValueChange={(v) => onTournamentChange(v || undefined)}
+        options={tournamentOptions}
+        placeholder="All tournaments"
+        searchPlaceholder="Search tournaments..."
+        isLoading={isLoadingTournaments}
+        disabled={isLoadingTournaments || isErrorTournaments}
+        triggerClassName={TRIGGER}
+      />
+    </div>
+
+    <button
+      type="button"
+      onClick={onResetColumns}
+      disabled={resetDisabled}
+      title="Reset columns to role defaults"
+      className="inline-flex h-10 items-center justify-center gap-2 rounded-[8px] border border-[var(--aqt-border-2)] bg-white/[0.025] px-3 text-xs font-semibold text-[var(--aqt-fg-muted)] transition-colors hover:bg-white/[0.05] hover:text-[var(--aqt-fg)] disabled:pointer-events-none disabled:opacity-40"
+    >
+      <RotateCcw className="h-3.5 w-3.5" />
+      Reset columns
+    </button>
+  </section>
 );
 
 export default HeroLeaderboardFiltersCard;

--- a/frontend/src/app/(site)/users/heroes-compare/components/HeroLeaderboardTable.tsx
+++ b/frontend/src/app/(site)/users/heroes-compare/components/HeroLeaderboardTable.tsx
@@ -1,13 +1,18 @@
-import Image from "next/image";
+"use client";
+
+import { useMemo, useState } from "react";
 import { Sword } from "lucide-react";
 
-import { Card } from "@/components/ui/card";
 import { Hero, HeroLeaderboardEntry } from "@/types/hero.types";
-import GlassGlow from "@/app/(site)/users/compare/components/GlassGlow";
+import HeroImage from "@/components/hero/HeroImage";
+import { heroVariantFromRole } from "@/components/hero/heroRole";
 
 import { COL, StatKey, ALL_STAT_OPTIONS, NUM_COLUMNS } from "../config/stat-columns";
+import { teamDotBackground } from "../utils/teamColor";
 import SelectableStatColumn from "./SelectableStatColumn";
 import StatColumnSkeleton from "./StatColumnSkeleton";
+
+const MAX_LEGEND_TEAMS = 12;
 
 interface HeroLeaderboardTableProps {
   selectedHero: Hero | undefined;
@@ -31,60 +36,102 @@ const HeroLeaderboardTable = ({
   sortDirs,
   onColumnSelect,
   onToggleSort,
-}: HeroLeaderboardTableProps) => (
-  <Card className="relative overflow-hidden">
-    <GlassGlow />
+}: HeroLeaderboardTableProps) => {
+  const [hoveredUserId, setHoveredUserId] = useState<number | null>(null);
+  const variant = heroVariantFromRole(selectedHero?.type ?? selectedHero?.role);
 
-    <div className="relative flex items-center gap-3 border-b border-border/50 px-5 py-3.5">
-      {selectedHero && (
-        <Image
-          src={selectedHero.image_path}
-          alt={selectedHero.name}
-          width={36}
-          height={36}
-          className="h-9 w-9 rounded-full border border-border/60 object-cover shadow-md"
-        />
-      )}
-      <div className="flex-1">
-        <p className="text-sm font-semibold leading-tight">
-          {selectedHero?.name ?? "Hero"}
-        </p>
-        <p className="mt-0.5 text-xs leading-none text-muted-foreground">
-          {selectedTournamentName ?? "All tournaments"}
-        </p>
-      </div>
-      {!isLoading && rows.length > 0 && (
-        <span className="rounded-full bg-background/20 px-2.5 py-1 text-xs font-medium text-muted-foreground ring-1 ring-border/40">
-          {rows.length} players
-        </span>
-      )}
-    </div>
+  const legendTeams = useMemo(() => {
+    const seen = new Map<string, { team: string; teamId: number | null }>();
+    for (const r of rows) {
+      if (r.team && !seen.has(r.team)) seen.set(r.team, { team: r.team, teamId: r.team_id });
+    }
+    return Array.from(seen.values());
+  }, [rows]);
 
-    <div className="relative overflow-x-auto">
-      <div className="flex min-w-max divide-x divide-border/40">
-        {isLoading ? (
-          Array.from({ length: NUM_COLUMNS }).map((_, i) => <StatColumnSkeleton key={i} />)
-        ) : rows.length === 0 ? (
-          <div className="flex w-full min-w-[600px] items-center justify-center gap-2 py-20 text-sm text-muted-foreground">
-            <Sword className="h-4 w-4 opacity-40" />
-            No data found for this hero{tournamentId ? " in this tournament" : ""}.
+  return (
+    <section className="overflow-hidden rounded-[var(--aqt-radius)] border border-[var(--aqt-border)] bg-[var(--aqt-card)]">
+      {/* Board head */}
+      <div className="flex items-center gap-3.5 border-b border-[var(--aqt-border)] bg-white/[0.012] px-5 py-4">
+        {selectedHero && <HeroImage hero={selectedHero} size={44} rounded="lg" />}
+        <div className="min-w-0">
+          <div className="flex items-center gap-2.5">
+            <span className="font-[family-name:var(--aqt-display)] text-2xl font-bold uppercase leading-none tracking-[0.03em]">
+              {selectedHero?.name ?? "Hero"}
+            </span>
+            {selectedHero && (
+              <span
+                className="rounded-[5px] px-1.5 py-0.5 text-[10px] font-bold uppercase leading-none tracking-[0.08em]"
+                style={{
+                  color: `var(--aqt-${variant})`,
+                  background: `color-mix(in srgb, var(--aqt-${variant}) 15%, transparent)`,
+                }}
+              >
+                {selectedHero.type ?? selectedHero.role}
+              </span>
+            )}
           </div>
-        ) : (
-          columnKeys.map((key, i) => (
-            <SelectableStatColumn
-              key={i}
-              def={COL[key]}
-              sortDir={sortDirs[i]}
-              options={ALL_STAT_OPTIONS}
-              data={rows}
-              onSelect={(k) => onColumnSelect(i, k)}
-              onToggleSort={() => onToggleSort(i)}
-            />
-          ))
+          <p className="mt-1 font-[family-name:var(--aqt-mono)] text-[11.5px] text-[var(--aqt-fg-dim)]">
+            {selectedTournamentName ?? "All tournaments"}
+            {tournamentId ? ` · scope #${tournamentId}` : ""}
+          </p>
+        </div>
+        {!isLoading && rows.length > 0 && (
+          <span className="ml-auto rounded-full border border-[var(--aqt-border-2)] bg-white/[0.03] px-[11px] py-[5px] font-[family-name:var(--aqt-mono)] text-[11px] text-[var(--aqt-fg-muted)]">
+            <em className="not-italic font-semibold text-[var(--aqt-teal)]">{rows.length}</em> players
+          </span>
         )}
       </div>
-    </div>
-  </Card>
-);
+
+      {/* Columns */}
+      <div className="overflow-x-auto">
+        <div className="flex min-w-max divide-x divide-[var(--aqt-border)]">
+          {isLoading ? (
+            Array.from({ length: NUM_COLUMNS }).map((_, i) => <StatColumnSkeleton key={i} />)
+          ) : rows.length === 0 ? (
+            <div className="flex w-full min-w-[600px] items-center justify-center gap-2 py-[90px] text-sm text-[var(--aqt-fg-dim)]">
+              <Sword className="h-4 w-4 opacity-40" />
+              No data found for this hero{tournamentId ? " in this tournament" : ""}.
+            </div>
+          ) : (
+            columnKeys.map((key, i) => (
+              <SelectableStatColumn
+                key={i}
+                def={COL[key]}
+                sortDir={sortDirs[i]}
+                options={ALL_STAT_OPTIONS}
+                data={rows}
+                hoveredUserId={hoveredUserId}
+                onHoverUser={setHoveredUserId}
+                onSelect={(k) => onColumnSelect(i, k)}
+                onToggleSort={() => onToggleSort(i)}
+              />
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Teams legend */}
+      {!isLoading && legendTeams.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 border-t border-[var(--aqt-border)] bg-white/[0.008] px-5 py-3 text-[11px] text-[var(--aqt-fg-dim)]">
+          <span className="text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--aqt-fg-faint)]">
+            Teams
+          </span>
+          {legendTeams.slice(0, MAX_LEGEND_TEAMS).map(({ team, teamId }) => (
+            <span key={team} className="inline-flex items-center gap-1.5 font-[family-name:var(--aqt-mono)] text-[var(--aqt-fg-muted)]">
+              <span
+                className="h-[9px] w-[9px] rounded-[2px]"
+                style={{ background: teamDotBackground(team, teamId) }}
+              />
+              {team}
+            </span>
+          ))}
+          {legendTeams.length > MAX_LEGEND_TEAMS && (
+            <span className="text-[var(--aqt-fg-faint)]">+{legendTeams.length - MAX_LEGEND_TEAMS} more</span>
+          )}
+        </div>
+      )}
+    </section>
+  );
+};
 
 export default HeroLeaderboardTable;

--- a/frontend/src/app/(site)/users/heroes-compare/components/RankBadge.tsx
+++ b/frontend/src/app/(site)/users/heroes-compare/components/RankBadge.tsx
@@ -2,27 +2,29 @@ interface RankBadgeProps {
   rank: number;
 }
 
+const BASE = "w-full text-center tabular-nums";
+
 const RankBadge = ({ rank }: RankBadgeProps) => {
   if (rank === 1)
     return (
-      <span className="w-6 shrink-0 text-center text-xs font-bold tabular-nums text-amber-400">
+      <span className={`${BASE} font-[family-name:var(--aqt-display)] text-[15px] font-extrabold text-[var(--aqt-gold)]`}>
         1
       </span>
     );
   if (rank === 2)
     return (
-      <span className="w-6 shrink-0 text-center text-xs font-semibold tabular-nums text-slate-300">
+      <span className={`${BASE} font-[family-name:var(--aqt-mono)] text-[11px] font-bold text-[hsl(210_14%_78%)]`}>
         2
       </span>
     );
   if (rank === 3)
     return (
-      <span className="w-6 shrink-0 text-center text-xs font-semibold tabular-nums text-amber-700/90">
+      <span className={`${BASE} font-[family-name:var(--aqt-mono)] text-[11px] font-bold text-[hsl(28_60%_56%)]`}>
         3
       </span>
     );
   return (
-    <span className="w-6 shrink-0 text-center text-xs tabular-nums text-muted-foreground/50">
+    <span className={`${BASE} font-[family-name:var(--aqt-mono)] text-[11px] font-semibold text-[var(--aqt-fg-faint)]`}>
       {rank}
     </span>
   );

--- a/frontend/src/app/(site)/users/heroes-compare/components/SelectableStatColumn.tsx
+++ b/frontend/src/app/(site)/users/heroes-compare/components/SelectableStatColumn.tsx
@@ -19,6 +19,8 @@ interface SelectableStatColumnProps {
   sortDir: "asc" | "desc";
   options: StatColumnDef[];
   data: HeroLeaderboardEntry[];
+  hoveredUserId: number | null;
+  onHoverUser: (userId: number | null) => void;
   onSelect: (key: StatKey) => void;
   onToggleSort: () => void;
 }
@@ -28,6 +30,8 @@ const SelectableStatColumn = ({
   sortDir,
   options,
   data,
+  hoveredUserId,
+  onHoverUser,
   onSelect,
   onToggleSort,
 }: SelectableStatColumnProps) => {
@@ -41,32 +45,39 @@ const SelectableStatColumn = ({
     [data, def, sortDir]
   );
 
-  const maxValue = useMemo(
-    () => sorted.reduce((m, r) => Math.max(m, def.getValue(r)), 0) || 1,
-    [sorted, def]
-  );
+  const { minValue, maxValue } = useMemo(() => {
+    if (sorted.length === 0) return { minValue: 0, maxValue: 1 };
+    let min = Infinity;
+    let max = -Infinity;
+    for (const r of sorted) {
+      const v = def.getValue(r);
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+    return { minValue: min, maxValue: max || 1 };
+  }, [sorted, def]);
 
   return (
-    <div className="min-w-[270px] flex-1">
-      <div className="flex flex-col items-center gap-1.5 border-b border-border/50 px-4 pb-3 pt-3">
-        <div className={`h-[3px] w-8 rounded-full opacity-80 ${def.accentColor}`} />
+    <div className="min-w-[286px] flex-1">
+      <div className="flex flex-col items-center gap-2 border-b border-[var(--aqt-border)] bg-white/[0.008] px-3.5 pb-3 pt-3.5">
+        <div className={`h-[3px] w-[34px] rounded-full ${def.accentColor}`} />
         <div className="flex items-center gap-1">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                className="flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground"
+                className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-[11.5px] font-bold uppercase tracking-[0.12em] text-[var(--aqt-fg)] transition-colors hover:bg-white/[0.05]"
               >
                 {def.shortLabel}
-                <ChevronDown className="h-3 w-3 opacity-60" />
+                <ChevronDown className="h-3 w-3 text-[var(--aqt-fg-faint)]" />
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="center" className="w-52">
+            <DropdownMenuContent align="center" className="max-h-[340px] w-52 overflow-y-auto">
               {options.map((opt) => (
                 <DropdownMenuItem
                   key={opt.key}
                   onSelect={() => onSelect(opt.key)}
-                  className={`cursor-pointer gap-2 ${opt.key === def.key ? "bg-muted/50 font-semibold" : ""}`}
+                  className={`cursor-pointer gap-2 ${opt.key === def.key ? "bg-white/[0.06] font-semibold" : ""}`}
                 >
                   <span className={`h-2 w-2 shrink-0 rounded-full ${opt.accentColor}`} />
                   {opt.shortLabel}
@@ -77,14 +88,10 @@ const SelectableStatColumn = ({
           <button
             type="button"
             onClick={onToggleSort}
-            className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-muted/30 hover:text-foreground"
+            className="inline-flex h-[26px] w-[26px] items-center justify-center rounded-md border border-transparent text-[var(--aqt-fg-faint)] transition-colors hover:border-[var(--aqt-border-2)] hover:bg-white/[0.05] hover:text-[var(--aqt-fg)]"
             title={sortDir === "asc" ? "Sort descending" : "Sort ascending"}
           >
-            {sortDir === "asc" ? (
-              <ArrowUp className="h-3 w-3" />
-            ) : (
-              <ArrowDown className="h-3 w-3" />
-            )}
+            {sortDir === "asc" ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />}
           </button>
         </div>
       </div>
@@ -95,10 +102,12 @@ const SelectableStatColumn = ({
             entry={entry}
             rank={i + 1}
             value={def.getValue(entry)}
+            minValue={minValue}
             maxValue={maxValue}
             barColor={def.barColor}
             formatValue={def.formatValue}
-            isEven={i % 2 === 0}
+            isHighlighted={entry.user_id === hoveredUserId}
+            onHoverUser={onHoverUser}
           />
         ))}
       </div>

--- a/frontend/src/app/(site)/users/heroes-compare/components/StatColumnSkeleton.tsx
+++ b/frontend/src/app/(site)/users/heroes-compare/components/StatColumnSkeleton.tsx
@@ -1,21 +1,21 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
 const StatColumnSkeleton = ({ rows = 15 }: { rows?: number }) => (
-  <div className="min-w-[270px] flex-1">
-    <div className="flex flex-col items-center gap-1.5 border-b border-border/50 px-4 pb-3 pt-3">
-      <Skeleton className="h-[3px] w-8 rounded-full" />
-      <Skeleton className="h-3 w-24" />
+  <div className="min-w-[286px] flex-1">
+    <div className="flex flex-col items-center gap-2 border-b border-[var(--aqt-border)] bg-white/[0.008] px-3.5 pb-3 pt-3.5">
+      <Skeleton className="h-[3px] w-[34px] rounded-full" />
+      <Skeleton className="h-4 w-24" />
     </div>
     <div>
       {Array.from({ length: rows }).map((_, i) => (
         <div
           key={i}
-          className={`flex items-center gap-3 px-4 py-[9px] ${i % 2 === 0 ? "bg-muted/[0.06]" : ""}`}
+          className="grid grid-cols-[26px_116px_1fr_52px] items-center gap-[9px] border-b border-white/[0.04] px-3.5 py-2"
         >
-          <Skeleton className="h-4 w-6 shrink-0" />
-          <Skeleton className="h-4 w-32 shrink-0" />
-          <Skeleton className="h-[22px] flex-1" />
-          <Skeleton className="h-4 w-12 shrink-0" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-5 w-full" />
+          <Skeleton className="h-4 w-full" />
         </div>
       ))}
     </div>

--- a/frontend/src/app/(site)/users/heroes-compare/utils/teamColor.ts
+++ b/frontend/src/app/(site)/users/heroes-compare/utils/teamColor.ts
@@ -1,0 +1,37 @@
+/**
+ * Deterministic team-color derivation for the Hero Compare board.
+ *
+ * The leaderboard API returns a team name (and id) but no brand color, so we
+ * derive a stable tint from the team identity. The same team always maps to the
+ * same hue, which lets the small color-dot beside each player act as a
+ * cross-column trace aid (mirrors the imported design mockup).
+ */
+
+const FALLBACK = "hsl(215 12% 30%)";
+
+/** FNV-1a style string hash → stable non-negative integer. */
+const hashString = (value: string): number => {
+  let h = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    h ^= value.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+};
+
+/** Stable hue (0–359) for a team key (name preferred, id as fallback). */
+export const teamHue = (team: string | null | undefined, teamId?: number | null): number => {
+  const key = team && team.trim() ? team : teamId != null ? `#${teamId}` : "";
+  if (!key) return 0;
+  return hashString(key) % 360;
+};
+
+/**
+ * CSS background for a team dot — a diagonal gradient keyed to the team hue,
+ * matching the mockup's tinted squares. Returns a neutral color when no team.
+ */
+export const teamDotBackground = (team: string | null | undefined, teamId?: number | null): string => {
+  if (!team && teamId == null) return FALLBACK;
+  const h = teamHue(team, teamId);
+  return `linear-gradient(135deg, hsl(${h} 72% 62%), hsl(${h} 58% 36%))`;
+};

--- a/frontend/src/types/hero.types.ts
+++ b/frontend/src/types/hero.types.ts
@@ -48,6 +48,8 @@ export interface HeroLeaderboardEntry {
   player_name: string;
   role: string | null;
   div: number;
+  team: string | null;
+  team_id: number | null;
   games_played: number;
   playtime_seconds: number;
   per10_eliminations: number;


### PR DESCRIPTION
Re-skin /users/heroes-compare to the --aqt-* design tokens (Tailwind utilities) per the imported "OWT" Claude Design mockup, and surface team identity in the leaderboard.

Frontend:
- New HeroCompareHero header (breadcrumb, headline, 4 summary stats from rows)
- Controls card + Reset columns button; restyled board head, columns, rows, rank badges, skeleton, empty state
- Team-color dot (deterministic HSL via new utils/teamColor.ts) + Teams legend
- Cross-column hover-highlight (lifted hoveredUserId; BarRow memoized)
- Drop the liquid-glass/glow treatment; preserve all data/query/URL-state logic
- SearchableImageSelect: optional triggerClassName (backward-compatible)
- hero.types: add team/team_id to HeroLeaderboardEntry

Backend (app-service + tournament-service, no migration):
- Join Team on the existing Player.team_id FK in the hero leaderboard query; return team/team_id (latest-overall player row semantics). Team color is derived on the frontend, division stays D{div}.